### PR TITLE
Fix markdown

### DIFF
--- a/docs/api-reference/dfuse/dfuse_example.md
+++ b/docs/api-reference/dfuse/dfuse_example.md
@@ -24,7 +24,7 @@ In this example, we'll sign up for a free account and get the WAX RNG abi using 
 }'
 ```
 
-4. Use the <span class="codeSample">abi</span> endpoint to get the WAX RNG smart contract endpoint. In the Header, set the Authorization to Bearer and use your JWT from the previous step.
+4. Use the `abi` endpoint to get the WAX RNG smart contract endpoint. In the Header, set the Authorization to Bearer and use your JWT from the previous step.
 
     ```
     curl -X GET \

--- a/docs/dapp-development/deploy-dapp-on-wax/deploy_docker.md
+++ b/docs/dapp-development/deploy-dapp-on-wax/deploy_docker.md
@@ -45,7 +45,7 @@ To modify the **hello-world** scripts to deploy your smart contract:
 
     Save the file. 
 
-5. Next, open **Makefile**. This file contains the scripts to run <span class="codeSample">cleos</span> and the WAX Docker Development image. 
+5. Next, open **Makefile**. This file contains the scripts to run `cleos` and the WAX Docker Development image.
 
     a. Type your contract name on Line 23.
     ```shell
@@ -66,10 +66,10 @@ To modify the **hello-world** scripts to deploy your smart contract:
     Save the file.
 
 
-    <strong>Note:</strong> <span class="codeSample">NODEOS_URL</span> is the only optional parameter. Its default value is the mainnet deployment address https://chain.wax.io/.  
+    <strong>Note:</strong> `NODEOS_URL` is the only optional parameter. Its default value is the mainnet deployment address https://chain.wax.io/.  
     {: .label .label-yellow }
 
-Once these changes have been made, you're ready to use the <span class="codeSample">make</span> scripts to build and deploy your smart contract.
+Once these changes have been made, you're ready to use the `make` scripts to build and deploy your smart contract.
 
 ## Deploy Your Smart Contract
 
@@ -81,7 +81,7 @@ To launch your WAX smart contract on the WAX Blockchain:
     make build
     ```
 
-    This creates <span class="codeSample">wax.wasm</span> and <span class="codeSample">wax.abi</span> in the **wax_deploy** folder.
+    This creates `wax.wasm` and `wax.abi` in the **wax_deploy** folder.
 
 2. **Generate keys for your smart contract's account.** From the command line, run:
 

--- a/docs/dapp-development/deploy-dapp-on-wax/deploy_source.md
+++ b/docs/dapp-development/deploy-dapp-on-wax/deploy_source.md
@@ -6,7 +6,7 @@ parent: Deploy Your dApp on WAX
 grand_parent: dApp Development
 ---
 
-In this guide, you'll use the <span class="codeSample">cleos set contract</span> command to deploy your smart contract to the WAX mainnet.
+In this guide, you'll use the `cleos set contract` command to deploy your smart contract to the WAX mainnet.
 
 Before you begin, you'll need to compile your smart contract and have your WASM and ABI files ready. Refer to [Smart Contract Quickstart](/wax-developer/docs/dapp_build) or [WAX-CDT Build Tools](/wax-developer/docs/cdt_cpp) for more information.
 
@@ -23,7 +23,7 @@ To deploy your smart contract to the WAX mainnet:
     cleos wallet open -n mywallet && cleos wallet unlock -n mywallet --password {wallet.pwd}
     ```
 
-2. Generate a public/private key pair that's used to create your smart contract's blockchain account. From the command line, use the <span class="codeSample">cleos create key</span> command:
+2. Generate a public/private key pair that's used to create your smart contract's blockchain account. From the command line, use the `cleos create key` command:
 
     ```shell
     cleos wallet create_key -n mywallet
@@ -32,7 +32,7 @@ To deploy your smart contract to the WAX mainnet:
     <strong>Note:</strong> You can also use an EOSIO compatible wallet (e.g., Scatter).
     {: .label .label-yellow }
 
-3. From the command line, use <span class="codeSample">cleos system newaccount</span> to create your smart contract's account. To run this command, you'll need to have the proper authority. This means that the wallet containing your primary account must be opened and unlocked. 
+3. From the command line, use `cleos system newaccount` to create your smart contract's account. To run this command, you'll need to have the proper authority. This means that the wallet containing your primary account must be opened and unlocked. 
 
     <table>
     <thead>
@@ -108,7 +108,7 @@ To deploy your smart contract to the WAX mainnet:
     <strong>Note:</strong> You'll need to repeat Steps 1 and 2 for each of your contracts. 
     {: .label .label-yellow }
 
-4. **Deploy.** From the command line, set your contract with the <span class="codeSample">cleos set contract</span> command: 
+4. **Deploy.** From the command line, set your contract with the `cleos set contract` command: 
 
     | Parameter | Example | Description
     | --- | ----------- | -------------------------- |

--- a/docs/dapp-development/deploy-dapp-on-wax/index.md
+++ b/docs/dapp-development/deploy-dapp-on-wax/index.md
@@ -32,8 +32,8 @@ The <a href="https://github.com/worldwide-asset-exchange/wax-blockchain" target=
 
 * Docker must be installed and configured to run without sudo. Linux users, refer to <a href="https://docs.docker.com/install/linux/linux-postinstall/" target="_blank">Post-installation steps for Linux</a> for more information.
 
-       <strong>Windows Subsystem for Linux Users:</strong> Docker configuration and installation requirements will vary depending on your WSL version. Recommended only for advanced Docker/Windows users. If you're running WSL 2, refer to <a href="https://docs.docker.com/docker-for-windows/wsl-tech-preview/" target="_blank">Docker Desktop WSL 2 Tech Preview</a> for more information.
-        {: .label .label-yellow }
+   <strong>Windows Subsystem for Linux Users:</strong> Docker configuration and installation requirements will vary depending on your WSL version. Recommended only for advanced Docker/Windows users. If you're running WSL 2, refer to <a href="https://docs.docker.com/docker-for-windows/wsl-tech-preview/" target="_blank">Docker Desktop WSL 2 Tech Preview</a> for more information.
+    {: .label .label-yellow }
 
 * make (VERSION 3.9 +)
 * A self-managed WAX Blockchain Account and its private key (to deploy the contract).

--- a/docs/dapp-development/docker-setup/docker_qstart_manage.md
+++ b/docs/dapp-development/docker-setup/docker_qstart_manage.md
@@ -8,13 +8,15 @@ grand_parent: dApp Development
 
 To exit your interactive bash session (without stopping your container), press `ctrl-p` + `ctrl-q` to send an escape sequence. The console prints:
 
-```shellread escape sequence```
+```shell
+read escape sequence
+```
 
 The command above returns you to your host's command prompt. You can verify that your container is still running by using the `docker ps` command:
 
 ```shell
 docker ps
-    ```
+```
 
 To re-attach to your bash session, use the `docker attach` command.
 
@@ -26,13 +28,13 @@ To stop your container, use the `docker stop` command.
 
 ```shell
 docker stop waxdev
-    ```
+```
 
 To re-start your container, use the `docker start` command.
 
 ```shell
 docker start waxdev
-    ```
+```
 
 Now that you've set up your Docker environment, you're ready to follow the guides in this section. While it's not required to complete the [WAX Blockchain Setup](/wax-developer/docs\dapp-development\wax-blockchain-setup) in the next tutorial, we still recommend downloading the source code to access code samples and **make** scripts.
 

--- a/docs/dapp-development/docker-setup/docker_qstart_manage.md
+++ b/docs/dapp-development/docker-setup/docker_qstart_manage.md
@@ -6,29 +6,29 @@ parent: Docker Setup
 grand_parent: dApp Development
 ---
 
-To exit your interactive bash session (without stopping your container), press <span class="codeSample">ctrl-p</span> <span class="codeSample">ctrl-q</span> to send an escape sequence. The console prints:
+To exit your interactive bash session (without stopping your container), press `ctrl-p` + `ctrl-q` to send an escape sequence. The console prints:
 
 ```shellread escape sequence```
 
-The command above returns you to your host's command prompt. You can verify that your container is still running by using the <span class="codeSample">docker ps</span> command:
+The command above returns you to your host's command prompt. You can verify that your container is still running by using the `docker ps` command:
 
 ```shell
 docker ps
     ```
 
-To re-attach to your bash session, use the <span class="codeSample">docker attach</span> command.
+To re-attach to your bash session, use the `docker attach` command.
 
 ```shell
 docker attach waxdev
 ```
 
-To stop your container, use the <span class="codeSample">docker stop</span> command.
+To stop your container, use the `docker stop` command.
 
 ```shell
 docker stop waxdev
     ```
 
-To re-start your container, use the <span class="codeSample">docker start</span> command.
+To re-start your container, use the `docker start` command.
 
 ```shell
 docker start waxdev

--- a/docs/dapp-development/docker-setup/docker_qstart_use.md
+++ b/docs/dapp-development/docker-setup/docker_qstart_use.md
@@ -6,7 +6,7 @@ parent: Docker Setup
 grand_parent: dApp Development
 ---
 
-Once your **waxdev** bash session starts, you can use common commands to interact with your container. For example, to list your container's contents, use the <span class="codeSample">ls</span> command.
+Once your **waxdev** bash session starts, you can use common commands to interact with your container. For example, to list your container's contents, use the `ls` command.
 
 ```shell
 ls
@@ -18,16 +18,16 @@ The console prints:
 bin  boot  dev  etc  home  lib  lib32  lib64  media  mnt  opt  proc  root  run  sbin  srv  sys  tmp  usr  var  wax
 ```
 
-The list above includes the **wax** directory that you shared when you started your **waxdev** container. You can <span class="codeSample">cd</span> into this directory when you're ready to [Create a Smart Contract](/wax-developer/docs/dapp-development/smart-contract-quickstart/dapp_hello_world).
+The list above includes the **wax** directory that you shared when you started your **waxdev** container. You can `cd` into this directory when you're ready to [Create a Smart Contract](/wax-developer/docs/dapp-development/smart-contract-quickstart/dapp_hello_world).
 
-<strong>Tip:</strong> Sharing your local host's folder with your waxdev Docker container allows you to create directories that exist on both your host and the docker container. This makes it easy to build and deploy your smart contracts using Docker. 
+<strong>Tip:</strong> Sharing your local host's folder with your waxdev Docker container allows you to create directories that exist on both your host and the docker container. This makes it easy to build and deploy your smart contracts using Docker.
 {: .label .label-yellow }
 
 ## Use Our Guides
 
 Throughout our dApp Development section, we'll list various steps required to run blockchain commands and build your smart contracts. For example:
 
-1. From the command line, use the <span class="codeSample">cleos</span> command to get blockchain information from the WAX mainnet.
+1. From the command line, use the `cleos` command to get blockchain information from the WAX mainnet.
 
 ```shell
 cleos -u https://chain.wax.io get info
@@ -38,7 +38,7 @@ When you start an interactive bash session, the *command line* is your Docker co
 
 <img src="/wax-developer/assets/img/docker_root.jpg"/>
 
-When you press <span class="codeSample">Enter</span> to run the command, the console prints a JSON response directly in your Docker container:
+When you press `Enter` to run the command, the console prints a JSON response directly in your Docker container:
 
 <img src="/wax-developer/assets/img/docker_results.jpg"/>
 
@@ -63,8 +63,3 @@ When you press <span class="codeSample">Enter</span> to run the command, the con
   "fork_db_head_block_id": "013e93c480c99a55ecc17b9afb48eae8f9980b01f5779462b1cd0b2551719578"
 }
     ```-->
-
-
-
-
-

--- a/docs/dapp-development/setup-local-dapp-environment/dapp_api.md
+++ b/docs/dapp-development/setup-local-dapp-environment/dapp_api.md
@@ -6,11 +6,11 @@ parent: Set Up a Local dApp Environment
 grand_parent: dApp Development
 ---
 
-The WAX mainnet exposes a set of **nodeos** API endpoints (RPC API), allowing you to interact with the WAX Blockchain. In production, this API is accessed from <span class="codeSample">https:<span></span>//chain.wax.io</span>.
+The WAX mainnet exposes a set of **nodeos** API endpoints (RPC API), allowing you to interact with the WAX Blockchain. In production, this API is accessed from `https://chain.wax.io`.
 
-Now that you have a local node running on your local development server, these endpoints can be accessed from your local IP address: <span class="codeSample">http:<span></span>//127.0.0.1:8888</span>. This API endpoint is initialized when you pass the <span class="codeSample">plugin eosio::chain_api_plugin</span> parameter to **nodeos**.
+Now that you have a local node running on your local development server, these endpoints can be accessed from your local IP address: `http://127.0.0.1:8888`. This API endpoint is initialized when you pass the `plugin eosio::chain_api_plugin` parameter to **nodeos**.
 
-To test your local RPC API, from the command line, make a **curl** request to the <span class="codeSample">get_info</span> endpoint:
+To test your local RPC API, from the command line, make a **curl** request to the `get_info` endpoint:
 
 ```
 curl --request POST \

--- a/docs/dapp-development/setup-local-dapp-environment/dapp_local.md
+++ b/docs/dapp-development/setup-local-dapp-environment/dapp_local.md
@@ -85,13 +85,13 @@ You're now running a local WAX node on your development server. Press Ctrl + c t
 
 To cleanly stop **nodeos**:
 
-1. From the command line, run <span class="codeSample">pkill</span>:
+1. From the command line, run `pkill`:
 
     ```shell
     pkill nodeos
     ```
 
-2. To verify that **nodeos** is no longer producing blocks, run the <span class="codeSample">tail</span> command to view the log:
+2. To verify that **nodeos** is no longer producing blocks, run the `tail` command to view the log:
 
     ```shell
     tail -f nodeos.log

--- a/docs/dapp-development/setup-local-dapp-environment/dapp_wallet.md
+++ b/docs/dapp-development/setup-local-dapp-environment/dapp_wallet.md
@@ -40,7 +40,7 @@ In this guide, you'll use **cleos** to create, open, and unlock a new wallet.
 
 ## Create a Default Wallet
 
-To create a new wallet, use the <span class="codeSample">wallet create</span> command:
+To create a new wallet, use the `wallet create` command:
 
 ```shell
 cleos wallet create --to-console
@@ -48,10 +48,10 @@ cleos wallet create --to-console
 
 This command creates a wallet named **default**, saved to a local path (e.g. "/home/username/eosio-wallet/default.wallet"). 
 
-<strong>Tip:</strong> You can also include the --name parameter to name a wallet: <span class="codeSample">cleos wallet create --name mywallet --to-console</span>.
+<strong>Tip:</strong> You can also include the --name parameter to name a wallet: `cleos wallet create --name mywallet --to-console`.
 {: .label .label-yellow }
 
-The <span class="codeSample">--to-console</span> parameter prints your password to the console. Be sure to save this password someplace safe (you'll need it to unlock your wallet).
+The `--to-console` parameter prints your password to the console. Be sure to save this password someplace safe (you'll need it to unlock your wallet).
 
 ```shell
 warn  2019-07-16T22:39:39.847 thread-0  wallet.cpp:223                save_wallet_file     ] saving wallet to file /home/username/eosio-wallet/./default.wallet
@@ -66,25 +66,25 @@ Without password imported keys will not be retrievable.
 
 ## Open and Unlock Your Wallet
 
-Wallets are closed by default (when starting a **keosd** instance). To open your wallet, use the <span class="codeSample">wallet open</span> command:
+Wallets are closed by default (when starting a **keosd** instance). To open your wallet, use the `wallet open` command:
 
 ```shell
 cleos wallet open
 ```
 
-The console prints out that your **default** wallet is open: <span class="codeSample">Opened: default</span>.
+The console prints out that your **default** wallet is open: `Opened: default`.
 
 
-<strong>Tip:</strong> You can also include the --name parameter to open a wallet by name: <span class="codeSample">cleos wallet open --name named-wallet</span>.
+<strong>Tip:</strong> You can also include the --name parameter to open a wallet by name: `cleos wallet open --name named-wallet`.
 {: .label .label-yellow }
 
-Now that your wallet is open, you'll need to unlock it. You can use the <span class="codeSample">--password</span> command to unlock it in one step. Use the password that was printed to the console when you created your wallet.
+Now that your wallet is open, you'll need to unlock it. You can use the `cleos wallet open --name named-wallet` command to unlock it in one step. Use the password that was printed to the console when you created your wallet.
 
 ```shell
 cleos wallet unlock --password PW5KRXKVx25yjL3FvxxY9YxYxxYY9Yxx99yyXTRH8DjppKpD9tKtVz
 ```
 
-The console prints out that your **default** wallet is unlocked: <span class="codeSample">Unlocked: default</span>.
+The console prints out that your **default** wallet is unlocked: `cleos wallet open --name named-wallet`.
 
 <strong>Tip:</strong> By default, **keosd** will auto-lock your wallets after 15 minutes of inactivity. To disable this feature, you'll need to modify the **/home/username/eosio-wallet/config.ini** flag to an extremely large number. Setting it to 0 will cause keosd to always lock your wallet.
 {: .label .label-yellow }
@@ -105,7 +105,7 @@ Wallets:
 ]
 ```
 
-<strong>Tip:</strong> If you come back to this step later (after terminating your **kleos** instance) and your **default** wallet isn't listed: <span class="codeSample">Wallets: []</span>, you'll need to Open and Unlock your wallet again.
+<strong>Tip:</strong> If you come back to this step later (after terminating your **kleos** instance) and your **default** wallet isn't listed: `cleos wallet open --name named-wallet`, you'll need to Open and Unlock your wallet again.
 {: .label .label-yellow }
 
 

--- a/docs/dapp-development/smart-contract-quickstart/dapp_account.md
+++ b/docs/dapp-development/smart-contract-quickstart/dapp_account.md
@@ -58,7 +58,7 @@ Every WAX Account must have at least one public key. There are two types of publ
 - **Owner Key:** Required. This is the primary public key, with full permissions and complete control. In a production account, you should never give this out for most transactions. This key has a private/public key record in your local wallet.
 - **Active Key:** Optional. This is a secondary key, which can be changed by the Owner key. It requires an additional private/public key pair listed in your local wallet. In production, use this key to vote, send, and receive transactions.
 
-To create an account for your smart contract, you'll need to create a public and private key pair from your local development wallet. You can do this using your wallet's <span class="codeSample">create_key</span> command:
+To create an account for your smart contract, you'll need to create a public and private key pair from your local development wallet. You can do this using your wallet's `create_key` command:
 
 <strong>Note:</strong> Your wallet must be opened and unlocked to create your keys.
 {: .label .label-yellow }
@@ -78,7 +78,7 @@ Store this key someplace that's easily accessible (you'll need this public key i
 
 ## Create a Smart Contract Account
 
-To create a smart contract WAX Account, use the <span class="codeSample">create account</span> command:
+To create a smart contract WAX Account, use the `create account` command:
 
 | Parameter | Example | Description
 | --- | ----------- | -------------------------- |
@@ -92,7 +92,7 @@ To create a smart contract WAX Account, use the <span class="codeSample">create 
 cleos create account eosio waxsc1 EOS4yxqE5KYv5XaB2gj6sZTUDiGzKm42KfiRPDCeXWZUsAZZVXk1F 
 ```
 
-**cleos** broadcasts the <span class="codeSample">create account</span> command to your local blockchain and your wallet signs this transaction with a HASH.
+**cleos** broadcasts the `create account` command to your local blockchain and your wallet signs this transaction with a HASH.
 
 ```shell
 executed transaction: 4ebdc2eabcd545c7f26679e95d729893ebd0df919850791daa79a10e4865f702  200 bytes  15013 us
@@ -104,7 +104,7 @@ You should now have a WAX Blockchain Account to associate with your smart contra
 
 ## Verify Your New Account
 
-To view your new account's information, use the <span class="codeSample">get account</span> command:
+To view your new account's information, use the `get account` command:
 
 ```shell
 cleos get account waxcustomer

--- a/docs/dapp-development/smart-contract-quickstart/dapp_dev_deploy.md
+++ b/docs/dapp-development/smart-contract-quickstart/dapp_dev_deploy.md
@@ -38,7 +38,7 @@ In this guide, you'll use **cleos** to deploy and test the wax smart contract yo
 
 ## Deploy Your Smart Contract
 
-To deploy your smart contract's WASM file to your local blockchain, use <span class="codeSample">cleos set contract</span> from the command line:
+To deploy your smart contract's WASM file to your local blockchain, use `cleos set contract` from the command line:
 
 | Parameter | Example | Description
 | --- | ----------- | -------------------------- |
@@ -65,7 +65,7 @@ Your smart contract should now be live on your local blockchain.
 
 ## Test Your Smart Contract
 
-To test your smart contract, use <span class="codeSample">cleos push action</span> from the command line:
+To test your smart contract, use `cleos push action` from the command line:
 
 | Parameter | Example | Description
 | --- | ----------- | -------------------------- |
@@ -87,7 +87,7 @@ executed transaction: 6a0b1489d903f2cacc6480830358f07aaf65b20bf1d7e855dc20097f4d
 warning: transaction executed locally, but may not be confirmed by the network yet         ]
 ```
 
-If you receive an error that the transaction took too long, run <span class="codeSample">cleos push action</span> again. If you still receive an error, try restarting **nodeos**.
+If you receive an error that the transaction took too long, run `cleos push action` again. If you still receive an error, try restarting **nodeos**.
 
 ```shell
 Error 3080006: Transaction took too long

--- a/docs/dapp-development/smart-contract-quickstart/dapp_hello_world.md
+++ b/docs/dapp-development/smart-contract-quickstart/dapp_hello_world.md
@@ -33,13 +33,13 @@ To create your first WAX smart contract using **eosio-init**:
     cd mycontracts
     ```
 
-2. From the command line, use **eosio-init** with the <span class="codeSample">-project</span> parameter. 
+2. From the command line, use **eosio-init** with the `-project` parameter.
 
     ```
     eosio-init -project wax
     ```
 
-    **eosio-init** uses the <span class="codeSample">-project</span> name to create the following directory structure:
+    **eosio-init** uses the `-project` name to create the following directory structure:
 
     - mycontracts/wax/include 
     - mycontracts/wax/ricardian 
@@ -119,7 +119,7 @@ EOSIO_DISPATCH(wax, (greet))
 
 ## Compile Your Contract
 
-To deploy your smart contract, you'll need to create a <span class="codeSample">.wasm</span> and <span class="codeSample">.abi</span> file. You can do this using the WAX Contract Development Toolkit (WAX-CDT).
+To deploy your smart contract, you'll need to create a `.wasm` and `.abi` file. You can do this using the WAX Contract Development Toolkit (WAX-CDT).
 
 1. Install [WAX-CDT](/wax-developer/docs/cdt) (if you haven't done so already).
 

--- a/docs/dapp-development/smart-contract-quickstart/smart_contract_basics.md
+++ b/docs/dapp-development/smart-contract-quickstart/smart_contract_basics.md
@@ -60,9 +60,9 @@ Transactions communicate using two models: inline and deferred.
 
 ### Permissions
 
-A smart contract and a WAX Blockchain Account communicate using the actions defined in your smart contract. You can secure your actions using WAX Account permissions. By including the <span class="codeSample">require_auth()</span> method in your actions, you can verify that an action call was initiated by your smart contract's blockchain account. You can also use the <span class="codeSample">require_auth()</span> method to secure WAX customer-specific actions, such as updating a user record. Requiring authentication on user-specific actions can ensure that only your customer can perform this action - not someone else. 
+A smart contract and a WAX Blockchain Account communicate using the actions defined in your smart contract. You can secure your actions using WAX Account permissions. By including the `require_auth()` method in your actions, you can verify that an action call was initiated by your smart contract's blockchain account. You can also use the `require_auth()` method to secure WAX customer-specific actions, such as updating a user record. Requiring authentication on user-specific actions can ensure that only your customer can perform this action - not someone else.
 
-Permissions can also enable your smart contracts to handle notifications and make action calls to other smart contracts (using the <span class="codeSample">eosio.code</span> permission).
+Permissions can also enable your smart contracts to handle notifications and make action calls to other smart contracts (using the `eosio.code` permission).
 
  Refer to EOSIO's <a href="https://developers.eos.io/eosio-nodeos/dev-docs/accounts-and-permissions" target="_blank">Accounts and Permissions</a> for more information.
 

--- a/docs/dapp-development/smart-contract-quickstart/smart_contract_basics.md
+++ b/docs/dapp-development/smart-contract-quickstart/smart_contract_basics.md
@@ -73,7 +73,7 @@ Every time you call one of your smart contract's actions from your app, a new in
 To persist data between the actions of one or more of your smart contracts, you'll need to use the **multi_index** table functionality. 
     
 <strong>Note:</strong> Persistent data is stored on the WAX node's RAM and impacts the amount of WAX that you'll need to stake for your smart contract.
-    {: .label .label-yellow }
+{: .label .label-yellow }
 
 
  Refer to EOSIO's <a href="https://developers.eos.io/eosio-home/dev-docs/data-persistence" target="_blank">Data Persistence</a> for more information.

--- a/docs/dapp-development/testnet-quickstart.md
+++ b/docs/dapp-development/testnet-quickstart.md
@@ -18,7 +18,7 @@ In this guide, you'll learn how to create Testnet accounts and deploy your smart
 
 3. To deploy your smart contracts, you'll need to create a wallet using your public and private keys. You can use the wallet features on <a href="https://local.bloks.io/wallet/transfer?nodeUrl=testnet.waxsweden.org&coreSymbol=WAX&corePrecision=8&systemDomain=eosio&hyperionUrl=https%3A%2F%2Ftestnet.waxsweden.org" target="_blank">Bloks.io</a>, or use our [Docker images](/wax-developer/docs/docker_qstart) to manage your wallet. 
 
-    To create a wallet from a Docker container, use the <span class="codeSample">cleos wallet</span> command:
+    To create a wallet from a Docker container, use the `cleos wallet` command:
 
     ```shell
     cleos rm -f ~/eosio-wallet/{account.name}.wallet &&
@@ -60,7 +60,7 @@ In this guide, you'll learn how to create Testnet accounts and deploy your smart
     cleos -u https://testnet.waxsweden.org set account permission {account.name} active --add-code
     ```
 
-3. **Deploy.** From the command line, set your contract with the <span class="codeSample">cleos set contract</span> command: 
+3. **Deploy.** From the command line, set your contract with the `cleos set contract` command: 
 
     ```shell
     cleos -u https://testnet.waxsweden.org set contract {account.name} $(pwd) waxnft.wasm waxnft.abi   

--- a/docs/dapp-development/wax-blockchain-setup/blockchain_verify.md
+++ b/docs/dapp-development/wax-blockchain-setup/blockchain_verify.md
@@ -6,7 +6,7 @@ parent: WAX Blockchain Setup
 grand_parent: dApp Development
 ---
 
-To verify your installation, you can use **cleos** to call the <span class="codeSample">get info</span> endpoint on the Wax Blockchain API. 
+To verify your installation, you can use **cleos** to call the `get info` endpoint on the Wax Blockchain API. 
 
 From the command line, enter the following:
 
@@ -14,7 +14,7 @@ From the command line, enter the following:
 cleos -u https://chain.wax.io get info
 ```
 
-If the [Blockchain Tools](/wax-developer/docs/blockchain_tools) installed successfully, this endpoint will return various details about the WAX Blockchain, including the <span class="codeSample">chain_id</span>, block producer, and most recent block height.
+If the [Blockchain Tools](/wax-developer/docs/blockchain_tools) installed successfully, this endpoint will return various details about the WAX Blockchain, including the `chain_id`, block producer, and most recent block height.
 
 
 ```json

--- a/docs/dapp-development/wax-blockchain-setup/index.md
+++ b/docs/dapp-development/wax-blockchain-setup/index.md
@@ -34,7 +34,7 @@ The WAX Source Code Repository includes a Hello World sample to quickly build an
     
 ### Dependencies
     
-<p>For a complete list of dependencies, refer to <a href="https://github.com/worldwide-asset-exchange/wax-blockchain/tree/develop/scripts" target="_blank">wax-blockchain/scripts</a> and locate the <span class="codeSample">wax_build_</span> file for your operating system.</p>
+<p>For a complete list of dependencies, refer to <a href="https://github.com/worldwide-asset-exchange/wax-blockchain/tree/develop/scripts" target="_blank">wax-blockchain/scripts</a> and locate the `wax_build_` file for your operating system.</p>
 
 ## System Requirements
 

--- a/docs/dapp-development/wax-cdt/cdt_use.md
+++ b/docs/dapp-development/wax-cdt/cdt_use.md
@@ -120,7 +120,7 @@ To customize the build scripts:
 
 1. Copy **wax-cdt/examples/hello/CMakeLists.txt** into **mycontracts** (your parent smart contract directory). 
 
-2. From **mycontracts**, open **CmakeLists.txt** and modify the <span class="codeSample">ExternalProject_Add</span> method. 
+2. From **mycontracts**, open **CmakeLists.txt** and modify the `ExternalProject_Add` method. 
 
 **mycontracts/CMakeLists.txt:**
 
@@ -181,7 +181,7 @@ mkdir build
 cd build
 ```
 
-7. Run <span class="codeSample">cmake</span> to write the necessary build files to the **build** directory.
+7. Run `cmake` to write the necessary build files to the **build** directory.
 
 ```
 cmake ..

--- a/docs/troubleshooting/index.md
+++ b/docs/troubleshooting/index.md
@@ -10,7 +10,7 @@ Below is a list of known issues and fixes (if available).
 
 **Error Description:** WAX Source Code Repository Build Issue
 
-After running <span class="codeSample">sudo ./wax_install.sh</span> to build the WAX Source Code Repository on **Ubuntu 18.04**, the command line reports an error "In function 'fork_once_func'" (around [90%]):
+After running `sudo ./wax_install.sh` to build the WAX Source Code Repository on **Ubuntu 18.04**, the command line reports an error "In function 'fork_once_func'" (around [90%]):
 
 ```
 Scanning dependencies of target test_cypher_suites

--- a/docs/tutorials/create-nft/nft_basics.md
+++ b/docs/tutorials/create-nft/nft_basics.md
@@ -12,10 +12,10 @@ The Simple Asset's video below includes everything you need to know about NFT da
 [Simple Assets Tutorial](https://www.youtube.com/watch?v=yNxNIVSRxG8)
 
 ## Data Structures
- 
-You can customize the way your NFTs display in a WAX marketplace by using the <span class="codeSample">asset</span> data structure. An asset data structure includes the asset's author (the smart contract that creates the asset), category (e.g. weapon, sticker, name of your game or collection), and key/value pairs of immutable and mutable data. 
 
-Immutable data includes asset attributes that can't be updated, and mutable data includes attributes that may change over an item's lifetime. For example, imagine that you've designed a race car game that offers the winner of Level 5 a new high-performance engine. 
+You can customize the way your NFTs display in a WAX marketplace by using the `asset` data structure. An asset data structure includes the asset's author (the smart contract that creates the asset), category (e.g. weapon, sticker, name of your game or collection), and key/value pairs of immutable and mutable data.
+
+Immutable data includes asset attributes that can't be updated, and mutable data includes attributes that may change over an item's lifetime. For example, imagine that you've designed a race car game that offers the winner of Level 5 a new high-performance engine.
 
 There may be attributes assigned to this engine that will never change, like the engine's name, manufacturer, and description. On the other hand, as the player continues to race, other attributes may change like the engine's wear, horsepower upgrades, and total mileage.
 
@@ -33,12 +33,12 @@ Refer to Simple Asset's <a href="https://github.com/CryptoLions/SimpleAssets#dat
 
 ## Actions
 
-Actions vary depending on which blockchain account owner is calling the action. 
+Actions vary depending on which blockchain account owner is calling the action.
 
 As the owner of your game or marketplace (author), you can:
 
 * Create assets and update mutable attributes from your smart contract.
-* Optionally, you can include the <span class="codeSample">requireClaim</span> flag. In the Simple Assets smart contract, the account initializing an asset transfer (or asset <span class="codeSample">create</span> action) pays for the required RAM. If the <span class="codeSample">requireClaim</span> flag is set to true (1), this flag posts an asset for the designated user to take. This designated WAX user pays for the RAM instead.
+* Optionally, you can include the `requireClaim` flag. In the Simple Assets smart contract, the account initializing an asset transfer (or asset `create` action) pays for the required RAM. If the `requireClaim` flag is set to true (1), this flag posts an asset for the designated user to take. This designated WAX user pays for the RAM instead.
 * Burn an asset, along with a memo.
 
 <!--The Simple Assets smart contract also allows authors to optionally save information about you and your assets. This can include instructions on how to interact with your assets in WAX marketplaces and asset explorers and other information that you'd like to communicate to external dApps, websites, and asset owners.-->
@@ -46,7 +46,7 @@ As the owner of your game or marketplace (author), you can:
 Asset owners can:
 
 * Transfer their assets to another WAX Account user.
-* Claim assets that you've posted with the <span class="codeSample">requireClaim</span> flag.
+* Claim assets that you've posted with the `requireClaim` flag.
 * Cancel an offer to transfer their asset to another WAX Account.
 * Lend and borrow assets using the delegate and undelegate actions.
 
@@ -64,11 +64,8 @@ There are four key tables included with the Simple Assets smart contract:
 
 ## Contract Details
 
-To download the **simpleassets.abi** file to your current directory, use the <span class="codeSample">cleos get code</span> command from your Docker interactive bash session.
+To download the **simpleassets.abi** file to your current directory, use the `cleos get code` command from your Docker interactive bash session.
 
 ```shell
 cleos -u https://chain.wax.io get code simpleassets -a simpleassets.abi
     ```
-
-
-

--- a/docs/tutorials/create-nft/nft_deploy.md
+++ b/docs/tutorials/create-nft/nft_deploy.md
@@ -1,5 +1,5 @@
 ---
-title: Deploy Your NFT Smart Contract 
+title: Deploy Your NFT Smart Contract
 layout: default
 nav_order: 90
 parent: Create Non-Fungible Tokens
@@ -8,7 +8,7 @@ grand_parent: Tutorials
 
 Next, we'll use WAX-CDT tools to deploy your NFT smart contract to the WAX mainnet. Refer to [WAX-CDT Deploy](/wax-developer/docs/deploy_source) for more information.
 
-1. From Docker, open and unlock your wallet. 
+1. From Docker, open and unlock your wallet.
 
     ```shell
     cleos wallet open -n mywallet && cleos wallet unlock -n mywallet --password {wallet.pwd}
@@ -20,19 +20,19 @@ Next, we'll use WAX-CDT tools to deploy your NFT smart contract to the WAX mainn
     cleos wallet create_key -n mywallet
     ```
 
-3. From the command line, use <span class="codeSample">cleos system newaccount</span>. The example below uses **waxdappacct1** as the primary WAX Account holder and creates a new smart contract account named **waxnftowner1**. To run this command, you'll need to have the proper authority. This means that the wallet containing your primary account must be opened and unlocked. 
+3. From the command line, use `cleos system newaccount`. The example below uses **waxdappacct1** as the primary WAX Account holder and creates a new smart contract account named **waxnftowner1**. To run this command, you'll need to have the proper authority. This means that the wallet containing your primary account must be opened and unlocked.
 
     ```shell
     cleos -u https://chain.wax.io system newaccount waxdappacct1 waxnftowner1 EOS7jEb46pDiWvA39faCoFn3jUdn6LfL51irdXbvfpuSko86iNU5x --stake-net '5.00000000 WAX' --stake-cpu '5.00000000 WAX' --buy-ram-kbytes 32
     ```
 
-4. To run the inline **create** action in the **simpleassets** smart contract, you'll need to give your new **waxnftowner1@active** permission the additional **eosio.code** permission. This permission enhances security and allows your smart contract to send inline actions. From the command line, run the <span class="codeSample">cleos set account permission</span> command, and include the literal <span class="codeSample">--add-code</span> parameter.
+4. To run the inline **create** action in the **simpleassets** smart contract, you'll need to give your new **waxnftowner1@active** permission the additional **eosio.code** permission. This permission enhances security and allows your smart contract to send inline actions. From the command line, run the `cleos set account permission` command, and include the literal `--add-code` parameter.
 
     ```shell
     cleos -u https://chain.wax.io set account permission waxnftowner1 active --add-code
     ```
 
-    To verify the new permission, use the <span class="codeSample">cleos get account</span> command:
+    To verify the new permission, use the `cleos get account` command:
 
     ```shell
      cleos -u https://chain.wax.io get account waxnftowner1
@@ -47,16 +47,8 @@ Next, we'll use WAX-CDT tools to deploy your NFT smart contract to the WAX mainn
      active    1:    1 EOS7jEb46pDiWvA39faCoFn3jUdn6LfL51irdXbvfpuSko86iNU5x, 1 waxnftowner1@eosio.code
     ```
 
-5. Finally, set your contract with the <span class="codeSample">cleos set contract</span> command (make sure that you're in the **waxnft** folder): 
+5. Finally, set your contract with the `cleos set contract` command (make sure that you're in the **waxnft** folder):
 
     ```shell
     cleos -u https://chain.wax.io set contract waxnftowner1 $(pwd) waxrng.wasm waxrng.abi
     ```
-
-
-
-
-
-
-
-

--- a/docs/tutorials/create-nft/nft_test.md
+++ b/docs/tutorials/create-nft/nft_test.md
@@ -10,7 +10,7 @@ Now that you've deployed your WAX NFT smart contract, it's time to run a test ac
 
 ## Create a WAX NFT
 
-From the command line, use the <span class="codeSample">cleos push action</span> command to call the **createnft** action.
+From the command line, use the `cleos push action` command to call the **createnft** action.
 
 ```shell
 cleos -u https://chain.wax.io push action waxnftowner1 createnft [] -p waxnftowner1@active
@@ -29,7 +29,7 @@ warning: transaction executed locally, but may not be confirmed by the network y
 
 ## Verify Your WAX NFT
 
-You can locate WAX NFTs in the **sassets** table, scoped by the NFT's owner. To display your NFT records, use the <span class="codeSample">cleos get table</span> command.
+You can locate WAX NFTs in the **sassets** table, scoped by the NFT's owner. To display your NFT records, use the `cleos get table` command.
 
 ```json
 cleos -u https://chain.wax.io get table simpleassets waxnftowner1 sassets  

--- a/docs/tutorials/create-nft/nft_use.md
+++ b/docs/tutorials/create-nft/nft_use.md
@@ -76,7 +76,7 @@ In this example, we'll write a smart contract that creates a WAX NFT Sticker usi
     EOSIO_DISPATCH(waxnft, (createnft))
     ```    
         
-    Save your changes. This contract creates a WAX NFT Sticker with the same author and owner account. Because the <span class="codeSample">requireClaim</span> flag is set to false, your smart contract account is charged the RAM and the asset is instantly assigned to the owner (you).
+    Save your changes. This contract creates a WAX NFT Sticker with the same author and owner account. Because the `requireClaim` flag is set to false, your smart contract account is charged the RAM and the asset is instantly assigned to the owner (you).
 
      * **idata** includes key/value pairs that can not change.
     * **mdata** includes key/value pairs that you can update.

--- a/docs/tutorials/create-wax-rng-smart-contract/rng_basics.md
+++ b/docs/tutorials/create-wax-rng-smart-contract/rng_basics.md
@@ -58,19 +58,19 @@ The WAX RNG **requestrand** action accepts the following parameters:
 <tr>
 <td>assoc_id</td>
 <td>1405</td>
-<td>Required <span class="codeSample">uint64_t</span>. A unique value assigned by you (e.g., job id, database id).</td>
+<td>Required `uint64_t`. A unique value assigned by you (e.g., job id, database id).</td>
 </tr>
 
 <tr>
 <td>signing_value</td>
 <td>84569725</td>
-<td>Required <span class="codeSample">uint64_t</span>. A pseudo-random number generated client-side or on the back-end. Must be unique and never used before, even by other users.</td>
+<td>Required `uint64_t`. A pseudo-random number generated client-side or on the back-end. Must be unique and never used before, even by other users.</td>
 </tr>
 
 <tr>
 <td>caller</td>
 <td>get_self()</td>
-<td>Required <span class="codeSample">name</span>. The smart contract account calling the <strong>orng.wax</strong> action.</td>
+<td>Required `name`. The smart contract account calling the <strong>orng.wax</strong> action.</td>
 </tr>
 
 </tbody>
@@ -98,13 +98,13 @@ To receive your random number from the WAX RNG service, your smart contract must
 <tr>
 <td>assoc_id</td>
 <td>1405</td>
-<td>Required <span class="codeSample">uint64_t</span>. A unique value assigned by you (e.g., job id, database id).</td>
+<td>Required `uint64_t`. A unique value assigned by you (e.g., job id, database id).</td>
 </tr>
 
 <tr>
 <td>random_value</td>
 <td >Refer to Description.</td>
-<td style="word-wrap:break-word">Required <span class="codeSample">checksum256</span>. The RSA signed random value returned from the WAX RNG service.<br />
+<td style="word-wrap:break-word">Required `checksum256`. The RSA signed random value returned from the WAX RNG service.<br />
     <strong>Example: </strong>0979df3b6cb654bfe059481b586c2277697e7f0bfcef3e0dd198e19b54bce278
 </td>
 </tr>
@@ -133,25 +133,25 @@ To call the WAX RNG **requestrand** external action, you'll need to use the acti
 <tr>
 <td>permission</td>
 <td>{ get_self(), "active"_n }</td>
-<td>Required <span class="codeSample">structure</span>. This is your WAX Blockchain Account and permission type. For example, if you're smart contract's blockchain account is named <strong>waxsc1</strong>, { get_self(), "active"_n } returns <strong>waxsc1@active</strong> permissions.</td>
+<td>Required `structure`. This is your WAX Blockchain Account and permission type. For example, if you're smart contract's blockchain account is named <strong>waxsc1</strong>, { get_self(), "active"_n } returns <strong>waxsc1@active</strong> permissions.</td>
 </tr>
 
 <tr>
 <td>code</td>
 <td>"orng.wax"_n</td>
-<td>Required <span class="codeSample">name</span>. The WAX RNG smart contract account.</td>
+<td>Required `name`. The WAX RNG smart contract account.</td>
 </tr>
 
 <tr>
 <td>action</td>
 <td>"requestrand"_n</td>
-<td>Required <span class="codeSample">string</span>. The action name in the WAX RNG smart contract.</td>
+<td>Required `string`. The action name in the WAX RNG smart contract.</td>
 </tr>
 
 <tr>
 <td>data</td>
 <td>std::tuple{ your_id, signing_value, get_self() })</td>
-<td>Required <span class="codeSample">fixed-size collection</span>. The parameters required for the requestrand action.
+<td>Required `fixed-size collection`. The parameters required for the requestrand action.
 </td>
 </tr>
 </tbody>

--- a/docs/tutorials/create-wax-rng-smart-contract/rng_deploy.md
+++ b/docs/tutorials/create-wax-rng-smart-contract/rng_deploy.md
@@ -8,7 +8,7 @@ grand_parent: Tutorials
 
 In this example, we'll use WAX-CDT tools to deploy your Lucky Number Generator smart contract. Refer to [WAX-CDT Deploy](/wax-developer/docs/deploy_source) for more information.
 
-1. From Docker, open and unlock your wallet. 
+1. From Docker, open and unlock your wallet.
 
     ```shell
     cleos wallet open -n mywallet && cleos wallet unlock -n mywallet --password {wallet.pwd}
@@ -20,19 +20,19 @@ In this example, we'll use WAX-CDT tools to deploy your Lucky Number Generator s
     cleos wallet create_key -n mywallet
     ```
 
-3. From the command line, use <span class="codeSample">cleos system newaccount</span>. The example below uses **waxdappacct1** as the primary WAX Account holder and creates a new smart contract account named **waxrng**. To run this command, you'll need to have the proper authority. This means that the wallet containing your primary account must be opened and unlocked. 
+3. From the command line, use `cleos system newaccount`. The example below uses **waxdappacct1** as the primary WAX Account holder and creates a new smart contract account named **waxrng**. To run this command, you'll need to have the proper authority. This means that the wallet containing your primary account must be opened and unlocked.
 
     ```shell
     cleos -u https://chain.wax.io system newaccount waxdappacct1 waxrng EOS7jEb46pDiWvA39faCoFn3jUdn6LfL51irdXbvfpuSko86iNU5x --stake-net '0.50000000 WAX' --stake-cpu '0.50000000 WAX' --buy-ram-kbytes 32
     ```
 
-4. To run the inline **requestrand** action on the **orng.wax** smart contract, you'll need to give your new **waxrng@active** permission the additional **eosio.code** permission. This permission enhances security and allows your smart contract to send inline actions. From the command line, run the <span class="codeSample">cleos set account permission</span> command, and include the literal <span class="codeSample">--add-code</span> parameter.
+4. To run the inline **requestrand** action on the **orng.wax** smart contract, you'll need to give your new **waxrng@active** permission the additional **eosio.code** permission. This permission enhances security and allows your smart contract to send inline actions. From the command line, run the `cleos set account permission` command, and include the literal `--add-code` parameter.
 
     ```shell
     cleos -u https://chain.wax.io set account permission waxrng active --add-code
     ```
 
-    To verify the new permission, use the <span class="codeSample">cleos get account</span> command:
+    To verify the new permission, use the `cleos get account` command:
 
     ```shell
      cleos -u https://chain.wax.io get account waxrng
@@ -47,9 +47,8 @@ In this example, we'll use WAX-CDT tools to deploy your Lucky Number Generator s
      active    1:    1 EOS7jEb46pDiWvA39faCoFn3jUdn6LfL51irdXbvfpuSko86iNU5x, 1 waxrng@eosio.code
     ```
 
-5. Finally, set your contract with the <span class="codeSample">cleos set contract</span> command: 
+5. Finally, set your contract with the `cleos set contract` command:
 
     ```shell
     cleos -u https://chain.wax.io set contract waxrng mycontracts/waxrng/build/waxrng waxrng.wasm waxrng.abi
     ```
-

--- a/docs/tutorials/create-wax-rng-smart-contract/rng_sample.md
+++ b/docs/tutorials/create-wax-rng-smart-contract/rng_sample.md
@@ -12,7 +12,7 @@ In this example, we'll create a smart contract that uses the WAX RNG service to 
 
 1. From the command line, navigate to your smart contracts directory. For this example, we'll use **mycontracts**.
 
-2. Use **eosio-init** with the <span class="codeSample">-project</span> parameter to create your smart contract template. 
+2. Use **eosio-init** with the `-project` parameter to create your smart contract template. 
 
     ```shelleosio-init -project waxrng```
     

--- a/docs/tutorials/create-wax-rng-smart-contract/rng_test.md
+++ b/docs/tutorials/create-wax-rng-smart-contract/rng_test.md
@@ -23,13 +23,13 @@ In this example, we'll use the following parameters:
 <tr>
 <td>customer_id</td>
 <td>1267</td>
-<td>Required <span class="codeSample">uint64_t</span>. Your internal database id for the customer.</td>
+<td>Required `uint64_t`. Your internal database id for the customer.</td>
 </tr>
 
 <tr>
 <td>signing_value</td>
 <td>445896213</td>
-<td>Required <span class="codeSample">uint64_t</span>. A pseudo-random number generated client-side.</td>
+<td>Required `uint64_t`. A pseudo-random number generated client-side.</td>
 </tr>
 
 </tbody>
@@ -37,7 +37,7 @@ In this example, we'll use the following parameters:
 
 ## Get a Random Number
 
-From the command line, use the <span class="codeSample">cleos push action</span> command to call the **getrandom** action.
+From the command line, use the `cleos push action` command to call the **getrandom** action.
 
 ```shell
 cleos -u https://chain.wax.io push action waxrng getrandom '["waxrng", 1267, 445896213]' -p waxrng@active
@@ -63,7 +63,7 @@ pending console output:
 
 ## Verify Your Random Number
 
-The callback function saves your random number to the **rngcustomers** table. To display the table values, use the <span class="codeSample">cleos get table</span> command.
+The callback function saves your random number to the **rngcustomers** table. To display the table values, use the `cleos get table` command.
 
 ```shell
 cleos -u https://chain.wax.io get table waxrng waxrng rngcustomers


### PR DESCRIPTION
* Replace `<span class="codeSample">content</span>` to markdown inline code: \`content\`
* Fix some code blocks that where not correctly formatted.
* Fix a couple of "note" blocks that where not correctly formatted.