### PR TITLE
How-to SimpleAssets (rebrand title)

### DIFF
--- a/docs/en/api-reference/rpc_api.md
+++ b/docs/en/api-reference/rpc_api.md
@@ -35,6 +35,6 @@ cleos -u [api-url] get info
 
 ## Additional Information and Third-Party Tools
 
-Refer to EOSIO's <a href="https://developers.eos.io/manuals/eos/v2.0/nodeos/plugins/chain_api_plugin/api-reference/index" target="_blank">RPC API</a> for a list of endpoints.
+Refer to <a href="https://docs.eosnetwork.com/leap/latest/nodeos/rpc_apis/" target="_blank">RPC API documentation </a> for a list of API calls.
 
 <a href="https://github.com/EOSIO/eosjs" target="_blank">eosjs</a> is a javascript API SDK that's used to easily communicate with the WAX RPC API. To simplify development, you can use this tool to access blockchain endpoints.

--- a/docs/en/dapp-development/convert_eos.md
+++ b/docs/en/dapp-development/convert_eos.md
@@ -9,12 +9,6 @@ lang: en
 
 WAX is fully compatible with EOS smart contracts and offers free blockchain accounts and cheaper fees. This guide provides an overview of how to deploy your EOS dApps to the WAX mainnet.
 
-<!--## What's Compatible
-
-* All EOSIO System Contracts
-* All EOSIO CDT libraries
-* <a href="https://github.com/EOSIO/eosjs" target="_blank">eosjs</a> API SDK-->
-
 ## Blockchain Accounts
 
 1. To deploy your smart contracts to the WAX mainnet, you'll need to create a self-managed WAX Blockchain Account.

--- a/docs/en/dapp-development/docker-setup/index.md
+++ b/docs/en/dapp-development/docker-setup/index.md
@@ -17,7 +17,7 @@ Using our Docker environment offers the following benefits:
 * Adds convenience and speed to your development efforts
 * Eliminates the need to manage source code 
 * Eliminates the need to meet our [Supported Operating Systems](/en/tools/os) requirements
-* Doesn't overwrite an existing installation of EOSIO
+* Doesn't overwrite an existing installation of Leap
 * Makes it easy to upgrade and try out new features
 * Makes it easy to switch between production and development environments
 

--- a/docs/en/dapp-development/setup-local-dapp-environment/dapp_wallet.md
+++ b/docs/en/dapp-development/setup-local-dapp-environment/dapp_wallet.md
@@ -63,7 +63,7 @@ Without password imported keys will not be retrievable.
 "PW5KRXKVx25yjL3FvxxY9YxYxxYY9Yxx99yyXTRH8DjppKpD9tKtVz"
 ```
 
-<strong>Tip:</strong> For a complete list of cleos wallet subcommands and parameters, refer to EOSIO's <a href="https://developers.eos.io/manuals/eos/v2.0/cleos/command-reference/wallet/index" target="_blank">Cleos Reference Guide</a>.
+<strong>Tip:</strong> For a complete list of cleos wallet subcommands and parameters, refer to <a href="https://docs.eosnetwork.com/leap/latest/cleos/command-reference/wallet/" target="_blank">Cleos Reference Guide</a>.
 {: .label .label-yellow }
 
 ## Open and Unlock Your Wallet
@@ -117,9 +117,9 @@ For development purposes, every WAX chain includes a default system user called 
 
 In your local development environment, this **eosio** user will simulate your WAX Blockchain Account. You can use the **eosio** user to create new accounts and push your smart contracts to your local blockchain, without having to worry about staking any WAX. 
 
-To sign transactions on behalf of the **eosio** system user, you'll need to import the EOSIO development key into your wallet. 
+To sign transactions on behalf of the **eosio** system user, you'll need to import the **eosio** development key into your wallet. 
 
-<strong>Important:</strong> This development key is the **same for all WAX and EOSIO developers**. Never use this key for a production WAX Account! Doing so will most certainly result in the loss of access to your account.
+<strong>Important:</strong> This development key is the **same for all WAX and Antelope developers**. Never use this key for a production WAX Account! Doing so will most certainly result in the loss of access to your account.
 {: .label .label-yellow }
 
 

--- a/docs/en/dapp-development/smart-contract-quickstart/dapp_account.md
+++ b/docs/en/dapp-development/smart-contract-quickstart/dapp_account.md
@@ -20,7 +20,7 @@ There are several different account types that you'll need to deploy your smart 
 
 In this guide, you'll use **cleos** to create a new WAX Blockchain Account that you can use to deploy your smart contract.
 
-<strong>Tip</strong> For a complete list of cleos create account subcommands and options, refer to EOSIO's <a href="https://developers.eos.io/manuals/eos/v2.0/cleos/command-reference/create/account" target="_blank">Cleos Reference Guide: create account</a>.
+<strong>Tip</strong> For a complete list of cleos create account subcommands and options, refer to <a href="https://docs.eosnetwork.com/leap/latest/cleos/command-reference/create/account" target="_blank">Cleos Reference Guide: create account</a>.
 {: .label .label-yellow }
 
 ## Before You Begin

--- a/docs/en/dapp-development/smart-contract-quickstart/smart_contract_basics.md
+++ b/docs/en/dapp-development/smart-contract-quickstart/smart_contract_basics.md
@@ -20,7 +20,7 @@ Smart contracts typically include header files, class inheritance, actions, perm
 
 ### Header Files
 
-C++ header files contain global declarations. Because WAX uses a fork of EOSIO, all of your WAX smart contracts will inherit from EOSIO contracts and classes. The <a href="https://github.com/worldwide-asset-exchange/wax-cdt/blob/master/libraries/eosiolib/eosio.hpp" target="_blank">eosio.hpp</a> header file must be included in every contract, and every contract must extend the <a href="https://github.com/worldwide-asset-exchange/wax-cdt/blob/master/libraries/eosiolib/contract.hpp" target="_blank">eosio::contract</a> class. 
+C++ header files contain global declarations. Because WAX uses a fork of EOS (Antelope), all of your WAX smart contracts will inherit from EOS contracts and classes. The <a href="https://github.com/worldwide-asset-exchange/wax-cdt/blob/master/libraries/eosiolib/eosio.hpp" target="_blank">eosio.hpp</a> header file must be included in every contract, and every contract must extend the <a href="https://github.com/worldwide-asset-exchange/wax-cdt/blob/master/libraries/eosiolib/contract.hpp" target="_blank">eosio::contract</a> class. 
 
 ```
   #include <eosio/eosio.hpp>
@@ -54,13 +54,11 @@ Transactions communicate using two models: inline and deferred.
 
 - **Inline:** An inline transaction is a synchronous-like communication model that executes in the same transaction scope. These actions are guaranteed to run in-order and at the same time the original action is called. If the transaction fails, you can revert changes in the previous actions.  
 
-    For an example of an inline transaction, refer to EOSIO's <a href="https://developers.eos.io/welcome/v2.0/smart-contract-guides/adding-inline-actions" target="_blank">Adding Inline Actions</a>.
+    For an example of an inline transaction, refer to EOS Network's guide <a href="https://docs.eosnetwork.com/docs/latest/getting-started/smart-contract-development/adding-inline-actions" target="_blank">Adding Inline Actions</a>.
 
 - **Deferred:** A deferred action is an action that's scheduled to run in the future, similar to an asynchronous call. These transactions are not guaranteed to run (there is a potential of it being dropped by the node). The original (calling) action is applied to the WAX Blockchain when the action runs, and can not be reverted if the deferred transaction fails. 
-    
-    For an example of a deferred transaction, refer to EOSIO's <a href="https://developers.eos.io/manuals/eosio.cdt/v1.7/best-practices/deferred_transactions" target="_blank">Deferred Transactions</a>.
 
-**Warning:** As of EOSIO 2.0 RC1 deferred transactions are deprecated.
+**Warning:** As of Leap 3.1 deferred transactions are deprecated.
 {: .label .label-yellow}
 
 ### Permissions
@@ -69,7 +67,7 @@ A smart contract and a WAX Blockchain Account communicate using the actions defi
 
 Permissions can also enable your smart contracts to handle notifications and make action calls to other smart contracts (using the `eosio.code` permission).
 
- Refer to EOSIO's <a href="https://developers.eos.io/welcome/v2.0/protocol-guides/accounts_and_permissions" target="_blank">Accounts and Permissions</a> for more information.
+ Refer to EOS Network's guide <a href="https://docs.eosnetwork.com/docs/latest/protocol/accounts_and_permissions" target="_blank">Accounts and Permissions</a> for more information.
 
 ### Persist Data
 
@@ -81,7 +79,7 @@ To persist data between the actions of one or more of your smart contracts, you'
 {: .label .label-yellow }
 
 
- Refer to EOSIO's <a href="https://developers.eos.io/welcome/v2.0/smart-contract-guides/data-persistence/" target="_blank">Data Persistence</a> for more information.
+ Refer to EOS Network's guide <a href="https://docs.eosnetwork.com/docs/latest/getting-started/smart-contract-development/data-persistence" target="_blank">Data Persistence</a> for more information.
 
 ### WAX Dispatchers
 

--- a/docs/en/dapp-development/wax-blockchain-setup/index.md
+++ b/docs/en/dapp-development/wax-blockchain-setup/index.md
@@ -19,7 +19,7 @@ If you'd like to access our sample contracts and scripts from your local drive o
 
 ## What's Included
 
-The WAX Blockchain is a fork of <a href="https://developers.eos.io/" target="_blank">EOSIO</a>. This <a href="https://github.com/worldwide-asset-exchange/wax-blockchain" target="_blank">WAX Blockchain Source Code Repository</a> includes and installs:
+The WAX Blockchain is a fork of <a href="https://docs.eosnetwork.com/" target="_blank">EOS (Antelope)</a>. This <a href="https://github.com/worldwide-asset-exchange/wax-blockchain" target="_blank">WAX Blockchain Source Code Repository</a> includes and installs:
 
 - WAX Blockchain source code
 - Dependencies

--- a/docs/en/tools/blockchain_tools.md
+++ b/docs/en/tools/blockchain_tools.md
@@ -13,7 +13,7 @@ To communicate with the WAX Blockchain, create a local development environment, 
 
 Used to store private keys. This program automatically starts when you initiate **cleos** commands and can start several instances on your local server.
 
-Refer to EOSIO's <a href="https://developers.eos.io/manuals/eos/v2.0/keosd/index" target="_blank">Introduction - keosd</a> for more information.
+Refer to EOS's <a href="https://docs.eosnetwork.com/leap/latest/keosd/" target="_blank">Introduction - keosd</a> for more information.
 
 ## nodeos 
 
@@ -21,10 +21,10 @@ This is the core WAX node daemon, used to run a local node on your server. You c
 
 Nodeos also allows you to communicate with the [WAX RPC API](/en/api-reference/rpc_api).
 
-Refer to EOSIO's <a href="https://developers.eos.io/manuals/eos/v2.0/nodeos/index" target="_blank">Overview - nodeos</a> for more information.
+Refer to EOS's <a href="https://docs.eosnetwork.com/leap/latest/nodeos/" target="_blank">Overview - nodeos</a> for more information.
 
 ## cleos
 
 Used to interact with your local blockchain and manage local wallets and accounts.
 
-Refer to EOSIO's <a href="https://developers.eos.io/manuals/eos/v2.0/cleos/index" target="_blank">Overview - cleos</a> for more information.
+Refer to EOS's <a href="https://docs.eosnetwork.com/leap/latest/cleos/" target="_blank">Overview - cleos</a> for more information.

--- a/docs/en/tutorials/create-wax-rng-smart-contract/rng_deploy.md
+++ b/docs/en/tutorials/create-wax-rng-smart-contract/rng_deploy.md
@@ -16,7 +16,7 @@ In this example, we'll use WAX-CDT tools to deploy your Lucky Number Generator s
     cleos wallet open -n mywallet && cleos wallet unlock -n mywallet --password {wallet.pwd}
     ```
 
-2. Using **cleos** or an EOSIO compatible wallet, create a new public/private key pair for your smart contract.
+2. Using **cleos** or an Antelope compatible wallet, create a new public/private key pair for your smart contract.
 
     ```shell
     cleos wallet create_key -n mywallet

--- a/docs/en/tutorials/howto_atomicassets/mutabledata.md
+++ b/docs/en/tutorials/howto_atomicassets/mutabledata.md
@@ -29,7 +29,7 @@ Technically speaking, there is no difference between mutable and immutable data 
 
 It is true that the smart contract can be modified to avoid this, but this would make it dubious and render it useless.
 
-AtomicAssets is the most popular smart contract from WAX Blockchain -as well as other EOSIO Blockchains- and is extremely well designed to be used in video games, thus having both mutable and immutable data. We will now learn how to modify this data.
+AtomicAssets is the most popular smart contract from WAX Blockchain -as well as other Antelope Blockchains- and is extremely well designed to be used in video games, thus having both mutable and immutable data. We will now learn how to modify this data.
 
 Here we can see an example of an NFT -from a card game- with immutable data to the left and mutable data to the right. In this case we can see that the card level (Lvl) can rise, as its “strong”, “shield”, “loot” and other attributes can.
 

--- a/docs/en/tutorials/howto_simpleassets/index.md
+++ b/docs/en/tutorials/howto_simpleassets/index.md
@@ -1,10 +1,10 @@
 ---
-title: Create Non-Fungible Tokens
+title: How-To SimpleAssets
 layout: default
 nav_order: 87
 parent: Tutorials
 has_children: true
-lang-ref: Create Non-Fungible Tokens
+lang-ref: How-To SimpleAssets
 lang: en
 ---
  
@@ -12,7 +12,7 @@ You can easily create non-fungible tokens (NFTs) on the WAX Blockchain using the
 
 <a href="https://www.simpleassets.io/" target="_blank">Simple Assets</a> is a standard developed by <a href="https://cryptolions.io/" target="_blank">CryptoLions</a>, an EOSIO and WAX block producer. Using the Simple Assets smart contract, you can quickly create in-game items, cards, stickers, and other unique collectibles. 
 
-In this guide, you'll learn how the Simple Assets smart contract works and use our step-by-step guide to create an NFT on the WAX Blockchain. If you'd like to jump right to the code, refer to [Use Simple Assets](/en/tutorials/create-nft/nft_basics).
+In this guide, you'll learn how the Simple Assets smart contract works and use our step-by-step guide to create an NFT on the WAX Blockchain. If you'd like to jump right to the code, refer to [Use Simple Assets](/en/tutorials/howto_simpleassets/nft_basics).
 
 ## How it Works
 

--- a/docs/en/tutorials/howto_simpleassets/index.md
+++ b/docs/en/tutorials/howto_simpleassets/index.md
@@ -10,7 +10,7 @@ lang: en
  
 You can easily create non-fungible tokens (NFTs) on the WAX Blockchain using the <a href="https://github.com/CryptoLions/SimpleAssets" target="_blank">Simple Assets</a> smart contract.
 
-<a href="https://www.simpleassets.io/" target="_blank">Simple Assets</a> is a standard developed by <a href="https://cryptolions.io/" target="_blank">CryptoLions</a>, an EOSIO and WAX block producer. Using the Simple Assets smart contract, you can quickly create in-game items, cards, stickers, and other unique collectibles. 
+<a href="https://www.simpleassets.io/" target="_blank">Simple Assets</a> is a standard developed by <a href="https://cryptolions.io/" target="_blank">CryptoLions</a>, an EOS and WAX block producer. Using the Simple Assets smart contract, you can quickly create in-game items, cards, stickers, and other unique collectibles. 
 
 In this guide, you'll learn how the Simple Assets smart contract works and use our step-by-step guide to create an NFT on the WAX Blockchain. If you'd like to jump right to the code, refer to [Use Simple Assets](/en/tutorials/howto_simpleassets/nft_basics).
 

--- a/docs/en/tutorials/howto_simpleassets/nft_basics.md
+++ b/docs/en/tutorials/howto_simpleassets/nft_basics.md
@@ -2,7 +2,7 @@
 title: Simple Assets Basics
 layout: default
 nav_order: 88
-parent: Create Non-Fungible Tokens
+parent: How-To SimpleAssets
 grand_parent: Tutorials
 lang-ref: Simple Assets Basics
 lang: en

--- a/docs/en/tutorials/howto_simpleassets/nft_deploy.md
+++ b/docs/en/tutorials/howto_simpleassets/nft_deploy.md
@@ -2,7 +2,7 @@
 title: Deploy Your NFT Smart Contract
 layout: default
 nav_order: 90
-parent: Create Non-Fungible Tokens
+parent: How-To SimpleAssets
 grand_parent: Tutorials
 lang-ref: Deploy Your NFT Smart Contract
 lang: en

--- a/docs/en/tutorials/howto_simpleassets/nft_test.md
+++ b/docs/en/tutorials/howto_simpleassets/nft_test.md
@@ -2,7 +2,7 @@
 title: Test Your NFT Smart Contract 
 layout: default
 nav_order: 91
-parent: Create Non-Fungible Tokens
+parent: How-To SimpleAssets
 grand_parent: Tutorials
 lang-ref: Test Your NFT Smart Contract 
 lang: en

--- a/docs/en/tutorials/howto_simpleassets/nft_use.md
+++ b/docs/en/tutorials/howto_simpleassets/nft_use.md
@@ -2,7 +2,7 @@
 title: Create a WAX NFT
 layout: default
 nav_order: 89
-parent: Create Non-Fungible Tokens
+parent: How-To SimpleAssets
 grand_parent: Tutorials
 lang-ref: Create a WAX NFT
 lang: en

--- a/docs/en/wax-bp/bp-json.md
+++ b/docs/en/wax-bp/bp-json.md
@@ -23,7 +23,7 @@ Every information you have to fill out should be pretty straight forward, howeve
 
 ### General Information:
 - **producer_account_name**: <br>
-Self-explanatory. However, if you are not familiar with the naming scheme in the EOSIO ecosystem: It is important to note, that you have to use the name that you also have used (or are planning to use) for the action “regproducer”. That means that your official guild name may differ from the guild name you use on-chain.
+Self-explanatory. However, if you are not familiar with the naming scheme in the Antelope ecosystem: It is important to note, that you have to use the name that you also have used (or are planning to use) for the action “regproducer”. That means that your official guild name may differ from the guild name you use on-chain.
 
 - **candidate_name**:<br>
 This is the field, where you can fill in the official name of your guild. Spaces are allowed.

--- a/docs/en/wax-infrastructure/api-archive-guide.md
+++ b/docs/en/wax-infrastructure/api-archive-guide.md
@@ -134,7 +134,7 @@ Now that we have setup the server and disk storage in a good way, let's go ahead
 
 ##### 8. Build and Configure the Software:
 
-WAX software is an open-source modified version of EOSIO software to suit the needs of the WAX Network.Currently the WAX accepted software build and version is v2.0.13wax01 created by [cc32d9](https://cc32d9.medium.com/) who is a member of the [EOS Amsterdam Guild](https://eosamsterdam.net/)
+WAX software is an open-source modified version of Antelope software to suit the needs of the WAX Network.Currently the WAX accepted software build and version is v2.0.13wax01 created by [cc32d9](https://cc32d9.medium.com/) who is a member of the [EOS Amsterdam Guild](https://eosamsterdam.net/)
 
 The latest waxbuild tag is always available on the [WAX Github](https://github.com/worldwide-asset-exchange/wax-blockchain/tags).
 

--- a/docs/en/wax-infrastructure/index.md
+++ b/docs/en/wax-infrastructure/index.md
@@ -10,7 +10,7 @@ lang: en
 
 Infrastructure is the backbone of any application and the same goes with WAX Blockchain and the Web3, DeFi, NFT applications built on top of it.
 
-Compared to other blockchains like Ethereum & Bitcoin, running WAX nodes is quite different and needs a good understanding of the underlying EOSIO blockchain software operations.
+Compared to other blockchains like Ethereum & Bitcoin, running WAX nodes is quite different and needs a good understanding of the underlying Antelope blockchain software operations.
 
 There are different types of nodes in WAX Blockchain ecosystem that can used for different purposes. These nodes include:
 
@@ -21,7 +21,7 @@ There are different types of nodes in WAX Blockchain ecosystem that can used for
 - [Full/Partial History nodes (Deserialized & Consumable data archive nodes)](/en/wax-infrastructure/hyperion-guide)
 - NFT standards and Marketplace specific nodes ([AtomicAssets, AtomicMarket](/en/wax-infrastructure/atomic-api-guide) & Simpleassets)
 
-For more detailed explaination on the different types of nodes and their use-cases, please refer: https://developers.eos.io/welcome/latest/getting-started-guide/index/#development-and-testing
+For more detailed explaination on the different types of nodes and their use-cases, please refer: https://docs.eosnetwork.com/leap/latest/nodeos/usage/node-setups/
 
 The guides presented here will share some best practices, help you get a deeper understanding on how you can setup and maintain the WAX blockchain infrastructure in a scalable & resilient way.
 

--- a/docs/es/api-reference/rpc_api.md
+++ b/docs/es/api-reference/rpc_api.md
@@ -35,6 +35,6 @@ cleos -u https://apiwax.3dkrender.com get info
 
 ## Información adicional y herramientas de terceros
 
-Puedes consultar este enlace de EOSIO (<a href="https://developers.eos.io/manuals/eos/v2.0/nodeos/plugins/chain_api_plugin/api-reference/index" target="_blank">RPC API</a>) para acceder a una lista completa de puntos de acceso.
+Puedes consultar <a href="https://docs.eosnetwork.com/leap/latest/nodeos/rpc_apis/" target="_blank">RPC API</a> para acceder a una lista completa de API calls.
 
 <a href="https://github.com/EOSIO/eosjs" target="_blank">eosjs</a> es un SDK de la API de javascript que se utiliza para comunicarse fácilmente con la API RPC de WAX. Para simplificar el desarrollo, puedes utilizar esta herramienta para llegar a los puntos de acceso de la blockchain.

--- a/docs/es/dapp-development/deploy-dapp-on-wax/deploy_source.md
+++ b/docs/es/dapp-development/deploy-dapp-on-wax/deploy_source.md
@@ -19,7 +19,7 @@ También necesitarás:
 
 Para desplegar tu contrato inteligente en la mainnet de WAX:
 
-1. Abre y desbloquea tu cartera.
+1. Abre y desbloquea tu wallet.
 
     ```shell
     cleos wallet open -n mywallet && cleos wallet unlock -n mywallet --password {wallet.pwd}
@@ -31,10 +31,10 @@ Para desplegar tu contrato inteligente en la mainnet de WAX:
     cleos wallet create_key -n mywallet
     ```
 
-    <strong>Nota:</strong> También puedes utilizar una cartera compatible con EOSIO (como Scatter, por ejemplo).
+    <strong>Nota:</strong> También puedes utilizar una wallet compatible con EOSIO (como Scatter, por ejemplo).
     {: .label .label-yellow }
 
-3. Desde la línea de comandos, utiliza `cleos system newaccount` para crear la cuenta de tu contrato inteligente. Para ejecutar este comando, necesitarás tener autoridad sobre la cartera que contiene tu cuenta principal, lo que significa que debe estar abierta y desbloqueada. 
+3. Desde la línea de comandos, utiliza `cleos system newaccount` para crear la cuenta de tu contrato inteligente. Para ejecutar este comando, necesitarás tener autoridad sobre la wallet que contiene tu cuenta principal, lo que significa que debe estar abierta y desbloqueada. 
 
     <table>
     <thead>

--- a/docs/es/dapp-development/docker-setup/index.md
+++ b/docs/es/dapp-development/docker-setup/index.md
@@ -17,7 +17,7 @@ El uso de nuestro entorno Docker ofrece las siguientes ventajas:
 * Añade comodidad y rapidez a tus tareas de desarrollo.
 * Elimina la necesidad de gestionar el código fuente.
 * Elimina la necesidad de cumplir con los requisitos de nuestros [Sistemas Operativos Compatibles](/es/tools/os).
-* No sobrescribe una instalación de EOSIO ya existente.
+* No sobrescribe una instalación de Leap ya existente.
 * Facilita la actualización y la prueba de nuevas funciones.
 * Facilita la alternancia entre los entornos de producción y desarrollo.
 

--- a/docs/es/dapp-development/setup-local-dapp-environment/dapp_wallet.md
+++ b/docs/es/dapp-development/setup-local-dapp-environment/dapp_wallet.md
@@ -1,5 +1,5 @@
 ---
-title: Crear una cartera
+title: Crear una wallet
 layout: default
 nav_order: 43
 parent: Set Up a Local dApp Environment
@@ -8,16 +8,16 @@ lang-ref: Create a Wallet
 lang: es
 ---
 
-Una cartera WAX es un repositorio cifrado y nominal de combinaciones de claves públicas y privadas que se almacenan en un archivo en su servidor local (no en la blockchain). Necesitarás crear una cartera de desarrollo para:
+Una wallet WAX es un repositorio cifrado y nominal de combinaciones de claves públicas y privadas que se almacenan en un archivo en su servidor local (no en la blockchain). Necesitarás crear una wallet de desarrollo para:
 
 - Crear cuentas locales en la Blockchain de WAX
 - Firmar las acciones realizadas en tu blockchain local
 
 ## Cómo funciona
 
-Para crear una cuenta en tu blockchain local, necesitarás tener una clave pública pregenerada **owner** (obligatoria) y una clave pública **active** (opcional). Puedes utilizar tu cartera de desarrollo local para crear y almacenar estas claves. 
+Para crear una cuenta en tu blockchain local, necesitarás tener una clave pública pregenerada **owner** (obligatoria) y una clave pública **active** (opcional). Puedes utilizar tu wallet de desarrollo local para crear y almacenar estas claves. 
 
-### Contenido predeterminado de la cartera - Combinaciones de claves públicas/privadas
+### Contenido predeterminado de la wallet - Combinaciones de claves públicas/privadas
 ```shell
 [[
     "EOS4yxqE5KYv5XaB2gj6sZTUDiGzKm42KfiRPDCeXWZUsAZZVXk1F",
@@ -29,31 +29,31 @@ Para crear una cuenta en tu blockchain local, necesitarás tener una clave públ
 ]
 ```
 
-Tu cartera utilizará estas claves para firmar las acciones de tu contrato inteligente y difundirá la firma a tu red local. Si la red confirma que la transacción es válida, se incluirá en un bloque de la cadena de bloques. 
+Tu wallet utilizará estas claves para firmar las acciones de tu contrato inteligente y difundirá la firma a tu red local. Si la red confirma que la transacción es válida, se incluirá en un bloque de la cadena de bloques. 
 
-<strong>Consejo:</strong> Las carteras no almacenan tokens, sólo la combinación de claves asociada a una cuenta de la blockchain. 
+<strong>Consejo:</strong> Las wallets no almacenan tokens, sólo la combinación de claves asociada a una cuenta de la blockchain. 
 {: .label .label-yellow }
 
-En esta guía, utilizarás **cleos** para crear, abrir y desbloquear una nueva cartera.
+En esta guía, utilizarás **cleos** para crear, abrir y desbloquear una nueva wallet.
 
 <strong>Nota:</strong> No es necesario ejecutar <strong>nodeos</strong> para completar estos pasos. **kleos** se iniciará automáticamente (si no se está ejecutando ya).
 {: .label .label-yellow }
 
 
-## Crear una cartera predeterminada
+## Crear una wallet predeterminada
 
-Para crear una cartera nueva, utiliza el comando `wallet create`:
+Para crear una wallet nueva, utiliza el comando `wallet create`:
 
 ```shell
 cleos wallet create --to-console
 ```
 
-Este comando crea una cartera llamada **default**, guardada en una ruta local (por ejemplo, "/home/nombredeusuario/eosio-wallet/default.wallet"). 
+Este comando crea una wallet llamada **default**, guardada en una ruta local (por ejemplo, "/home/nombredeusuario/eosio-wallet/default.wallet"). 
 
-<strong>Consejo:</strong> También puedes incluir el parámetro --name para nombrar una cartera: `cleos wallet create --name mywallet --to-console`.
+<strong>Consejo:</strong> También puedes incluir el parámetro --name para nombrar una wallet: `cleos wallet create --name mywallet --to-console`.
 {: .label .label-yellow }
 
-El parámetro `--to-console` muestra tu contraseña en la consola. Asegúrate de guardar esta contraseña en un lugar seguro (la necesitarás para desbloquear tu cartera).
+El parámetro `--to-console` muestra tu contraseña en la consola. Asegúrate de guardar esta contraseña en un lugar seguro (la necesitarás para desbloquear tu wallet).
 
 ```shell
 warn  2019-07-16T22:39:39.847 thread-0  wallet.cpp:223                save_wallet_file     ] saving wallet to file /home/username/eosio-wallet/./default.wallet
@@ -63,42 +63,42 @@ Without password imported keys will not be retrievable.
 "PW5KRXKVx25yjL3FvxxY9YxYxxYY9Yxx99yyXTRH8DjppKpD9tKtVz"
 ```
 
-<strong>Consejo:</strong> Para obtener una lista completa de los subcomandos y parámetros de la cartera cleos, consulta la <a href="https://developers.eos.io/manuals/eos/v2.0/cleos/command-reference/wallet/index" target="_blank">Guía de referencia Cleos</a> de EOSIO.
+<strong>Consejo:</strong> Para obtener una lista completa de los subcomandos y parámetros de la wallet cleos, consulta la <a href="hhttps://docs.eosnetwork.com/leap/latest/cleos/command-reference/wallet" target="_blank">Guía de referencia Cleos</a> de EOS Network.
 {: .label .label-yellow }
 
-## Abrir y desbloquear tu cartera
+## Abrir y desbloquear tu wallet
 
-Las carteras están cerradas por defecto (cuando se inicia una instancia de **keosd**). Para abrir tu cartera, utiliza el comando `wallet open`:
+Las wallets están cerradas por defecto (cuando se inicia una instancia de **keosd**). Para abrir tu wallet, utiliza el comando `wallet open`:
 
 ```shell
 cleos wallet open
 ```
 
-La consola muestra que tu cartera **default** está abierta: `Opened: default`.
+La consola muestra que tu wallet **default** está abierta: `Opened: default`.
 
 
-<strong>Consejo:</strong> También puedes incluir el parámetro --name para abrir una cartera según su nombre: `cleos wallet open --name named-wallet`.
+<strong>Consejo:</strong> También puedes incluir el parámetro --name para abrir una wallet según su nombre: `cleos wallet open --name named-wallet`.
 {: .label .label-yellow }
 
-Ahora que tu cartera está abierta, necesitarás desbloquearla. Puedes utilizar el comando `cleos wallet open --name named-wallet` para desbloquearlo en un solo paso. Utiliza la contraseña que se mostró en la consola cuando creaste tu cartera.
+Ahora que tu wallet está abierta, necesitarás desbloquearla. Puedes utilizar el comando `cleos wallet open --name named-wallet` para desbloquearlo en un solo paso. Utiliza la contraseña que se mostró en la consola cuando creaste tu wallet.
 
 ```shell
 cleos wallet unlock --password PW5KRXKVx25yjL3FvxxY9YxYxxYY9Yxx99yyXTRH8DjppKpD9tKtVz
 ```
 
-La consola mostrará que tu cartera **default** está desbloqueada: `cleos wallet open --name named-wallet`.
+La consola mostrará que tu wallet **default** está desbloqueada: `cleos wallet open --name named-wallet`.
 
-<strong>Consejo:</strong> Por defecto, **keosd** bloqueará automáticamente tus carteras tras 15 minutos de inactividad. Para desactivar esta función, tendrás que ajustar el indicador **/home/username/eosio-wallet/config.ini** con un número muy elevado. Ponerlo a 0 hará que keosd mantenga tu cartera siempre bloqueada.
+<strong>Consejo:</strong> Por defecto, **keosd** bloqueará automáticamente tus wallets tras 15 minutos de inactividad. Para desactivar esta función, tendrás que ajustar el indicador **/home/username/eosio-wallet/config.ini** con un número muy elevado. Ponerlo a 0 hará que keosd mantenga tu wallet siempre bloqueada.
 {: .label .label-yellow }
 
 
-Para determinar si tu cartera está Bloqueada/Desbloqueada, puedes utilizar el siguiente comando:
+Para determinar si tu wallet está Bloqueada/Desbloqueada, puedes utilizar el siguiente comando:
 
 ```shell
 cleos wallet list
 ```
 
-La consola mostrará los nombres de tus carteras, con un asterisco (*) para indicar que tu cartera está desbloqueada:
+La consola mostrará los nombres de tus wallets, con un asterisco (*) para indicar que tu wallet está desbloqueada:
 
 ```shell
 Wallets:
@@ -107,7 +107,7 @@ Wallets:
 ]
 ```
 
-<strong>Consejo:</strong> Si vuelves a este paso más tarde (después de terminar tu instancia de **kleos**) y tu cartera **default** no aparece en la lista: `cleos wallet open --name named-wallet`, tendrás que abrirla y desbloquearla de nuevo.
+<strong>Consejo:</strong> Si vuelves a este paso más tarde (después de terminar tu instancia de **kleos**) y tu wallet **default** no aparece en la lista: `cleos wallet open --name named-wallet`, tendrás que abrirla y desbloquearla de nuevo.
 {: .label .label-yellow }
 
 
@@ -117,9 +117,9 @@ Para fines de desarrollo, cada cadena WAX incluye un usuario del sistema por def
 
 En tu entorno de desarrollo local, este usuario **eosio** simulará tu cuenta de WAX Blockchain. Puedes utilizar el usuario **eosio** para crear nuevas cuentas y enviar tus contratos inteligentes a tu blockchain local, sin tener que preocuparte de comprar WAX.
 
-Para firmar las transacciones en nombre del usuario del sistema **eosio**, tendrás que importar la clave de desarrollo de EOSIO a tu cartera. 
+Para firmar las transacciones en nombre del usuario del sistema **eosio**, tendrás que importar la clave de desarrollo de **eosio** a tu wallet. 
 
-<strong>Importante:</strong> Esta clave de desarrollo es **la misma para todos los desarrolladores de WAX y EOSIO**. Nunca uses esta clave para una cuenta WAX de producción. Si lo haces, es muy probable que pierdas el acceso a tu cuenta.
+<strong>Importante:</strong> Esta clave de desarrollo es **la misma para todos los desarrolladores de WAX y Antelope**. Nunca uses esta clave para una cuenta WAX de producción. Si lo haces, es muy probable que pierdas el acceso a tu cuenta.
 {: .label .label-yellow }
 
 
@@ -127,7 +127,7 @@ Para firmar las transacciones en nombre del usuario del sistema **eosio**, tendr
 cleos wallet import --private-key 5KQwrPbwdL6PhXujxW37FSSQZ1JiwsST4cqQzDeyXtP79zkvFD3
 ```
 
-La consola mostrará que tu clave de desarrollo ha sido importada en: (tu clave privada de la cartera).
+La consola mostrará que tu clave de desarrollo ha sido importada en: (tu clave privada de la wallet).
 
 ```shell
 imported private key for: EOS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV

--- a/docs/es/dapp-development/setup-local-dapp-environment/index.md
+++ b/docs/es/dapp-development/setup-local-dapp-environment/index.md
@@ -30,7 +30,7 @@ Cuando inicias **nodeos** con varios plug-ins de desarrollo, este lanza un nodo 
 
 También puedes utilizar una clave de desarrollo y una cuenta del sistema incorporadas para: 
 
-- **Crear una cartera de desarrollo.** Esto es necesario para crear cuentas.
+- **Crear una wallet de desarrollo.** Esto es necesario para crear cuentas.
 - **Crear una cuenta de contratos.** Cada uno de tus contratos debe estar asociado a una cuenta.
 - **Crear usuarios de prueba.** Puedes crear tantas cuentas locales como necesites y financiarlas con tokens locales.
 
@@ -39,4 +39,4 @@ También puedes utilizar una clave de desarrollo y una cuenta del sistema incorp
 Antes de configurar tu entorno de desarrollo local:
 
 - Tendrás que completar nuestro [Inicio rápido de Docker](/es/dapp-development/docker-setup/) (recomendado) o usar la [Configuración de la Blockchain de WAX](/es/dapp-development/wax-blockchain-setup/) para poder utilizar el código fuente.
-- Ten a mano un documento de texto o una app de notas. Tendrás que utilizar una contraseña para tu cartera y una clave pública para crear cuentas. 
+- Ten a mano un documento de texto o una app de notas. Tendrás que utilizar una contraseña para tu wallet y una clave pública para crear cuentas. 

--- a/docs/es/dapp-development/smart-contract-quickstart/dapp_account.md
+++ b/docs/es/dapp-development/smart-contract-quickstart/dapp_account.md
@@ -20,7 +20,7 @@ Hay varios tipos de cuentas diferentes que necesitarás para desplegar tus contr
 
 En esta guía, utilizarás **cleos** para crear una nueva cuenta en la Blockchain de WAX, que te permitirá desplegar tu contrato inteligente.
 
-<strong>Consejo</strong> Para ver una lista completa de los subcomandos y opciones de creación de cuentas de cleos, visita la <a href="https://developers.eos.io/manuals/eos/v2.0/cleos/command-reference/create/account" target="_blank">Guía de referencia de Cleos: crear una cuenta</a> de EOSIO.
+<strong>Consejo</strong> Para ver una lista completa de los subcomandos y opciones de creación de cuentas de cleos, visita la <a href="https://docs.eosnetwork.com/leap/latest/cleos/command-reference/create/account" target="_blank">Guía de referencia de Cleos: crear una cuenta</a> de EOS Network.
 {: .label .label-yellow }
 
 ## Antes de empezar
@@ -36,7 +36,7 @@ En esta guía, utilizarás **cleos** para crear una nueva cuenta en la Blockchai
         --http-validate-host=false \
         --verbose-http-errors >> nodeos.log 2>&1 &
     ```
-- Tu cartera debe estar abierta y desbloqueada
+- Tu wallet debe estar abierta y desbloqueada
     ```shell
     cleos wallet open
     ```
@@ -57,12 +57,12 @@ You don't have any wallet!-->
 
 Cada cuenta de WAX debe tener al menos una clave pública. Hay dos tipos de claves públicas, basadas en los permisos de la cuenta:
 
-- **Clave del propietario:** Requerida. Esta es la clave pública principal, con todos los permisos y el control absoluto. En una cuenta de producción, nunca deberías proporcionarla para la mayoría de las transacciones. Esta clave tiene un registro de clave privada/pública en tu cartera local.
-- **Clave activa:** Opcional. Esta es una clave secundaria, que puede ser cambiada por la clave del Propietario. Requiere un par de claves privadas/públicas adicionales en tu cartera local. En producción, usa esta clave para valorar, enviar y recibir transacciones.
+- **Clave del propietario:** Requerida. Esta es la clave pública principal, con todos los permisos y el control absoluto. En una cuenta de producción, nunca deberías proporcionarla para la mayoría de las transacciones. Esta clave tiene un registro de clave privada/pública en tu wallet local.
+- **Clave activa:** Opcional. Esta es una clave secundaria, que puede ser cambiada por la clave del Propietario. Requiere un par de claves privadas/públicas adicionales en tu wallet local. En producción, usa esta clave para valorar, enviar y recibir transacciones.
 
-Para crear una cuenta para tu contrato inteligente, necesitarás crear un par de claves públicas y privadas desde tu cartera de desarrollo local. Puedes hacerlo utilizando el comando `create_key` de tu cartera:
+Para crear una cuenta para tu contrato inteligente, necesitarás crear un par de claves públicas y privadas desde tu wallet de desarrollo local. Puedes hacerlo utilizando el comando `create_key` de tu wallet:
 
-<strong>Nota:</strong> Tu cartera debe estar abierta y desbloqueada para crear las claves.
+<strong>Nota:</strong> Tu wallet debe estar abierta y desbloqueada para crear las claves.
 {: .label .label-yellow }
 
 ```shell
@@ -86,7 +86,7 @@ Para crear una cuenta WAX de contrato inteligente, utiliza el comando `create ac
 | --- | ----------- | -------------------------- |
 | creator | eosio | El nombre de la cuenta principal que crea la nueva cuenta. En producción, esta es tu cuenta de WAX. |
 | name | waxsc1 | El nombre de la nueva cuenta. Los nombres de las cuentas deben tener menos de 13 caracteres y sólo contener letras [a-z] y números [1-5]. |
-| OwnerKey | EOS4yxqE5KYv5XaB2gj6sZTUDiGzKm42KfiRPDCeXWZUsAZZVXk1F | Clave pública, creada a partir de tu cartera de desarrollo local. |
+| OwnerKey | EOS4yxqE5KYv5XaB2gj6sZTUDiGzKm42KfiRPDCeXWZUsAZZVXk1F | Clave pública, creada a partir de tu wallet de desarrollo local. |
 
 ### Ejemplo
 
@@ -94,7 +94,7 @@ Para crear una cuenta WAX de contrato inteligente, utiliza el comando `create ac
 cleos create account eosio waxsc1 EOS4yxqE5KYv5XaB2gj6sZTUDiGzKm42KfiRPDCeXWZUsAZZVXk1F 
 ```
 
-**cleos** transmite el comando `create account` a tu blockchain local y tu cartera firma esta transacción con un HASH.
+**cleos** transmite el comando `create account` a tu blockchain local y tu wallet firma esta transacción con un HASH.
 
 ```shell
 executed transaction: 4ebdc2eabcd545c7f26679e95d729893ebd0df919850791daa79a10e4865f702  200 bytes  15013 us

--- a/docs/es/dapp-development/smart-contract-quickstart/dapp_dev_deploy.md
+++ b/docs/es/dapp-development/smart-contract-quickstart/dapp_dev_deploy.md
@@ -28,7 +28,7 @@ En esta guía, usarás **cleos** para desplegar y probar el contrato inteligente
         --http-validate-host=false \
         --verbose-http-errors >> nodeos.log 2>&1 &
     ```
-- Tu cartera debe estar abierta y desbloqueada
+- Tu wallet debe estar abierta y desbloqueada
     ```shell
     cleos wallet open
     ```

--- a/docs/es/dapp-development/smart-contract-quickstart/smart_contract_basics.md
+++ b/docs/es/dapp-development/smart-contract-quickstart/smart_contract_basics.md
@@ -20,7 +20,7 @@ Los contratos inteligentes suelen incluir archivos de cabecera, herencia de clas
 
 ### Archivos de cabecera
 
-Los archivos de cabecera de C++ contienen declaraciones globales. Como WAX utiliza una rama de EOSIO, todos sus contratos inteligentes heredarán de los contratos y clases de EOSIO. El archivo <a href="https://github.com/worldwide-asset-exchange/wax-cdt/blob/master/libraries/eosiolib/eosio.hpp" target="_blank">eosio.hpp</a> debe incluirse en todos los contratos, y todo contrato debe incluir la clase <a href="https://github.com/worldwide-asset-exchange/wax-cdt/blob/master/libraries/eosiolib/contract.hpp" target="_blank">eosio::contract</a>. 
+Los archivos de cabecera de C++ contienen declaraciones globales. Como WAX utiliza una rama de EOS (Antelope), todos sus contratos inteligentes heredarán de los contratos y clases de EOS. El archivo <a href="https://github.com/worldwide-asset-exchange/wax-cdt/blob/master/libraries/eosiolib/eosio.hpp" target="_blank">eosio.hpp</a> debe incluirse en todos los contratos, y todo contrato debe incluir la clase <a href="https://github.com/worldwide-asset-exchange/wax-cdt/blob/master/libraries/eosiolib/contract.hpp" target="_blank">eosio::contract</a>. 
 
 ```
   #include <eosio/eosio.hpp>
@@ -54,13 +54,11 @@ Las transacciones se comunican utilizando dos modelos: inline y diferido.
 
 - **Inline:** Una transacción inline es un modelo de comunicación de tipo síncrono que se ejecuta en el mismo ámbito de la transacción. Se garantiza que estas acciones se ejecutan en orden y al mismo tiempo que se llama a la acción original. Si la transacción falla, se pueden revertir los cambios en las acciones anteriores.  
 
-    Para ver un ejemplo de transacción inline, visita la guía de EOSIO <a href="https://developers.eos.io/welcome/v2.0/smart-contract-guides/adding-inline-actions" target="_blank">Añadir acciones inline</a>.
+    Para ver un ejemplo de transacción inline, visita la guía de EOS Network <a href="https://docs.eosnetwork.com/docs/latest/getting-started/smart-contract-development/adding-inline-actions" target="_blank">Añadir acciones inline</a>.
 
 - **Diferido:** Una acción diferida es una acción que está programada para ejecutarse en el futuro, similar a una llamada asíncrona. No se garantiza que estas transacciones se ejecuten (existe la posibilidad de que el nodo las abandone). La acción original (de llamada) se aplica a la Blockchain de WAX cuando la acción se ejecuta, y no puede ser revertida si la transacción diferida falla. 
-    
-    Para ver un ejemplo, visita la guía de EOSIO <a href="https://developers.eos.io/manuals/eosio.cdt/v1.7/best-practices/deferred_transactions" target="_blank">Transacciones diferidas</a>.
 
-**Advertencia:** A partir de EOSIO 2.0 RC1, las transacciones diferidas quedan obsoletas.
+**Advertencia:** A partir de Leap 3.1, las transacciones diferidas quedan obsoletas.
 {: .label .label-yellow}
 
 ### Permisos
@@ -69,7 +67,7 @@ Un contrato inteligente y una cuenta de la Blockchain de WAX se comunican utiliz
 
 Los permisos también pueden permitir que tus contratos inteligentes manejen notificaciones y hagan llamadas de acción a otros contratos inteligentes (usando el permiso `eosio.code`).
 
- Para más información, visita la guía de <a href="https://developers.eos.io/welcome/v2.0/protocol-guides/accounts_and_permissions" target="_blank">Cuentas y permisos</a> de EOSIO.
+ Para más información, visita la guía <a href="https://docs.eosnetwork.com/docs/latest/protocol/accounts_and_permissions" target="_blank">Cuentas y permisos</a> de EOS Network.
 
 ### Datos persistentes
 
@@ -81,7 +79,7 @@ Para persistir los datos entre las acciones de uno o más de sus contratos intel
 {: .label .label-yellow }
 
 
- Para más información, visita la guía <a href="https://developers.eos.io/welcome/v2.0/smart-contract-guides/data-persistence/" target="_blank">Persistencia de datos</a> de EOSIO.
+ Para más información, visita la guía <a href="https://docs.eosnetwork.com/docs/latest/getting-started/smart-contract-development/data-persistence" target="_blank">Persistencia de datos</a> de EOS Network.
 
 ### Despachadores de WAX
 

--- a/docs/es/dapp-development/testnet-quickstart.md
+++ b/docs/es/dapp-development/testnet-quickstart.md
@@ -18,9 +18,9 @@ En esta guía, aprenderás a crear cuentas de Testnet y a desplegar tus contrato
 
 2. Desde la página de inicio de Testnet, consigue tokens de WAX gratuitos para financiar tu nueva cuenta. 
 
-3. Para desplegar tus contratos inteligentes, necesitarás crear una cartera utilizando tus claves públicas y privadas. Puedes utilizar las funciones de cartera en <a href="https://local.bloks.io/wallet/transfer?nodeUrl=testnet.waxsweden.org&coreSymbol=WAX&corePrecision=8&systemDomain=eosio&hyperionUrl=https%3A%2F%2Ftestnet.waxsweden.org" target="_blank">Bloks.io</a>, o usar nuestras [imágenes de Docker](/es/dapp-development/docker-setup/) para controlar tu cartera. 
+3. Para desplegar tus contratos inteligentes, necesitarás crear una wallet utilizando tus claves públicas y privadas. Puedes utilizar las funciones de wallet en <a href="https://local.bloks.io/wallet/transfer?nodeUrl=testnet.waxsweden.org&coreSymbol=WAX&corePrecision=8&systemDomain=eosio&hyperionUrl=https%3A%2F%2Ftestnet.waxsweden.org" target="_blank">Bloks.io</a>, o usar nuestras [imágenes de Docker](/es/dapp-development/docker-setup/) para controlar tu wallet. 
 
-    Para crear una cartera desde un contenedor Docker, usa el comando `cleos wallet`:
+    Para crear una wallet desde un contenedor Docker, usa el comando `cleos wallet`:
 
     ```shell
     cleos rm -f ~/eosio-wallet/{account.name}.wallet &&
@@ -29,9 +29,9 @@ En esta guía, aprenderás a crear cuentas de Testnet y a desplegar tus contrato
     cleos wallet import -n {account.name} --private-key {owner.privatekey}
     ```
 
-    Guarda la contraseña de tu cartera en un lugar seguro: la necesitarás para ejecutar los comandos de la blockchain.
+    Guarda la contraseña de tu wallet en un lugar seguro: la necesitarás para ejecutar los comandos de la blockchain.
 
-4. Una vez que tengas una cartera configurada con tu cuenta de Testnet, puedes apostar por NET, CPU y RAM desde Bloks.io o tu contenedor Docker.
+4. Una vez que tengas una wallet configurada con tu cuenta de Testnet, puedes apostar por NET, CPU y RAM desde Bloks.io o tu contenedor Docker.
 
     Comprar RAM:
 
@@ -47,7 +47,7 @@ En esta guía, aprenderás a crear cuentas de Testnet y a desplegar tus contrato
 
 ## Despliegue de contratos inteligentes en la Testnet de WAX
 
-<strong>Consejo:</strong> Para completar estos pasos, asegúrate de que tu cartera está abierta y desbloqueada. Consulta la sección de Resolución de problemas que hay más abajo para obtener más información al respecto.
+<strong>Consejo:</strong> Para completar estos pasos, asegúrate de que tu wallet está abierta y desbloqueada. Consulta la sección de Resolución de problemas que hay más abajo para obtener más información al respecto.
 {: .label .label-yellow }
 
 1. Desde una sesión interactiva de Docker bash, navega a tu directorio de contratos inteligentes y crea tu contrato inteligente.
@@ -72,7 +72,7 @@ En esta guía, aprenderás a crear cuentas de Testnet y a desplegar tus contrato
 
 ## Resolución de problemas
 
-Si recibes errores de cartera y/o autorización, es posible que tengas que abrir y desbloquear tu cartera:
+Si recibes errores de wallet y/o autorización, es posible que tengas que abrir y desbloquear tu wallet:
 
 ```shell
 cleos wallet open -n {account.name} &&

--- a/docs/es/dapp-development/wax-blockchain-setup/index.md
+++ b/docs/es/dapp-development/wax-blockchain-setup/index.md
@@ -19,7 +19,7 @@ Si quieres acceder a nuestros contratos y scripts de muestra desde tu disco loca
 
 ## Qué incluye
 
-WAX Blockchain es un fork de <a href="https://developers.eos.io/" target="_blank">EOSIO</a>. Este <a href="https://github.com/worldwide-asset-exchange/wax-blockchain" target="_blank">repositorio de código fuente de WAX Blockchain</a> incluye e instala:
+WAX Blockchain es un fork de <a href="https://docs.eosnetwork.com/" target="_blank">EOS (Antelope)</a>. Este <a href="https://github.com/worldwide-asset-exchange/wax-blockchain" target="_blank">repositorio de código fuente de WAX Blockchain</a> incluye e instala:
 
 - Código fuente de WAX Blockchain
 - Dependencias

--- a/docs/es/wax-infra/api-archive-guide.md
+++ b/docs/es/wax-infra/api-archive-guide.md
@@ -134,7 +134,7 @@ Ahora que hemos configurado bien el servidor y el almacenamiento en disco, sigam
 
 ##### 8. Crear y configurar el software:
 
-El software WAX es una versión modificada de código abierto del software EOSIO para adaptarse a las necesidades de la red WAX. Actualmente, la versión del software WAX aceptada es la v2.0.13wax01, creada por [cc32d9](https://cc32d9.medium.com/), que es miembro del [Gremio de EOS Amsterdam](https://eosamsterdam.net/)
+El software WAX es una versión modificada de código abierto del software Antelope para adaptarse a las necesidades de la red WAX. Actualmente, la versión del software WAX aceptada es la v2.0.13wax01, creada por [cc32d9](https://cc32d9.medium.com/), que es miembro del [Gremio de EOS Amsterdam](https://eosamsterdam.net/)
 
 El último tag de waxbuild está siempre disponible en el [Github de WAX](https://github.com/worldwide-asset-exchange/wax-blockchain/tags).
 

--- a/docs/es/wax-infra/hyperion-guide.md
+++ b/docs/es/wax-infra/hyperion-guide.md
@@ -7,7 +7,7 @@ lang-ref: Full/Partial History nodes using Hyperion
 lang: es
 ---
 
-Tener una accesibilidad estable a los datos consumibles es esencial para las aplicaciones Web3 en una blockchain. Existen muchos ejemplos de utilidad que se les puede atribuir a los datos del historial, como la contabilidad, los impuestos, el seguimiento de las transacciones, la gestión de carteras, etc. 
+Tener una accesibilidad estable a los datos consumibles es esencial para las aplicaciones Web3 en una blockchain. Existen muchos ejemplos de utilidad que se les puede atribuir a los datos del historial, como la contabilidad, los impuestos, el seguimiento de las transacciones, la gestión de wallets, etc. 
 
 Hoy en día existen múltiples soluciones del historial que ofrecen diferentes características y funcionalidades, todas ellas con sus diferentes requisitos en términos de infraestructura. La siguiente guía presenta los pasos necesarios para configurar una solución de historial escalable y resistente basada en Hyperion.
 

--- a/docs/es/wax-infra/index.md
+++ b/docs/es/wax-infra/index.md
@@ -10,7 +10,7 @@ lang: es
 
 La infraestructura es la columna vertebral de cualquier aplicación y lo mismo ocurre con WAX Blockchain y las aplicaciones Web3, DeFi y NFT construidas sobre esta.
 
-En comparación con otras cadenas de bloques como Ethereum y Bitcoin, el funcionamiento de los nodos de WAX es bastante diferente y requiere una buena comprensión acerca de las operaciones del software de la blockchain EOSIO.
+En comparación con otras cadenas de bloques como Ethereum y Bitcoin, el funcionamiento de los nodos de WAX es bastante diferente y requiere una buena comprensión acerca de las operaciones del software de la blockchain Antelope.
 
 Existen distintos tipos de nodos en el ecosistema de la blockchain de WAX que pueden utilizarse para diferentes propósitos. Estos nodos incluyen:
 
@@ -21,7 +21,7 @@ Existen distintos tipos de nodos en el ecosistema de la blockchain de WAX que pu
 - Nodos de historial completo/parcial (nodos de archivo de datos deserializados y consumibles)
 - Nodos específicos de Marketplace y estándares NFTs (AtomicAssets, AtomicMarket y Simpleassets)
 
-Para una explicación más detallada sobre los diferentes tipos de nodos y sus respectivos usos, consulta este enlace: https://developers.eos.io/welcome/latest/getting-started-guide/index/#development-and-testing
+Para una explicación más detallada sobre los diferentes tipos de nodos y sus respectivos usos, consulta este enlace: https://docs.eosnetwork.com/leap/latest/nodeos/usage/node-setups/
 
 Las guías aquí presentes comparten algunos de los mejores procedimientos y te ayudarán a comprender mejor cómo puedes configurar y mantener la infraestructura de la blockchain de WAX, de forma que sea escalable y resistente.
 


### PR DESCRIPTION
Normalization of the index dedicated to the creation of NFTs with the SimpleAssets standard to appear as an alternative to AtomicAssets.