### PR TITLE
Change wax.bloks.io to waxblock.io

### DIFF
--- a/docs/de/wax-bp/bp-json.md
+++ b/docs/de/wax-bp/bp-json.md
@@ -103,7 +103,7 @@ cleos -u https://wax.blacklusion.io push action producerjson set '{"owner":"blac
 Vor allem für Einsteiger ist bloks.io eine gute Option, da es einen benutzerfreundlicheren Weg als ein CLI-Befehl bietet.
 
 ### Zum producerjson contract navigieren:
-[link](https://wax.bloks.io/account/producerjson?loadContract=true&tab=Actions&account=producerjson&scope=producerjson&limit=100&action=set).
+[link](https://waxblock.io/account/producerjson?action=set#contract-actions).
 ![](/assets/img/wax-bp/bp-json/img01.png){:class="img-responsive"}
 
 ### Füllen Sie die Informationen aus und senden Sie sie ab
@@ -111,7 +111,7 @@ Wählen Sie "set" und geben Sie Ihre Informationen ein. Als Kontoname verwenden 
 
 ![](/assets/img/wax-bp/bp-json/img02.png){:class="img-responsive"}
 
-Wenn Sie alles richtig gemacht haben, wird bloks.io Ihre erfolgreiche Transaktion bestätigen. Sie können sich diese Beispieltransaktion ansehen [here](https://wax.bloks.io/transaction/4bfb8f1219abd7f5e231bf54100c35604c0a655d6ff50925a472afdcf6e4bfe9).
+Wenn Sie alles richtig gemacht haben, wird bloks.io Ihre erfolgreiche Transaktion bestätigen. Sie können sich diese Beispieltransaktion ansehen [here](https://waxblock.io/transaction/4bfb8f1219abd7f5e231bf54100c35604c0a655d6ff50925a472afdcf6e4bfe9).
 
 ![](/assets/img/wax-bp/bp-json/img03.png){:class="img-responsive"}
 

--- a/docs/en/dapp-development/dapp_environments.md
+++ b/docs/en/dapp-development/dapp_environments.md
@@ -60,8 +60,8 @@ Below you'll find WAX versions, URLs, and development environment information.
 </tr>
 <tr>
 <td>Blockchain Explorer</td>
-<td><a href="https://wax.bloks.io/" target="_blank">https:<span></span>//wax.bloks.io</a></td>
-<td>Bloks.io block explorer.</td>
+<td><a href="https://waxblock.io/" target="_blank">https:<span></span>//waxblock.io</a></td>
+<td>waxblock.io block explorer.</td>
 </tr>
 
 <tr>

--- a/docs/en/tutorials/howto_atomicassets/collection_struct.md
+++ b/docs/en/tutorials/howto_atomicassets/collection_struct.md
@@ -45,7 +45,7 @@ The description and identification data are entered according to the following s
 ]
 ```
 
-If we create the collection from an interface like [https://wax.bloks.io](https://wax.bloks.io/account/atomicassets?loadContract=true&tab=Actions&account=atomicassets&scope=atomicassets&limit=100&action=createcol) we will have to fill in this data entry:
+If we create the collection from an interface like [https://waxblock.io](https://waxblock.io/account/atomicassets?action=createcol#contract-actions) we will have to fill in this data entry:
 
 ![AtomicAssets - createcol action](/assets/img/tutorials/howto_atomicassets/createcol_atomicassets.png)
 

--- a/docs/en/wax-bp/bp-json.md
+++ b/docs/en/wax-bp/bp-json.md
@@ -103,7 +103,7 @@ cleos -u https://wax.blacklusion.io push action producerjson set '{"owner":"blac
 Especially when you are starting out, bloks.io is a great option, since it offers a more user friendly way than a CLI-Command.
 
 ### Go to the producerjson contract:
-Click on this [link](https://wax.bloks.io/account/producerjson?loadContract=true&tab=Actions&account=producerjson&scope=producerjson&limit=100&action=set) to access the producerjson smartcontract.
+Click on this [link](https://waxblock.io/account/producerjson?action=set#contract-actions) to access the producerjson smartcontract.
 ![](/assets/img/wax-bp/bp-json/img01.png){:class="img-responsive"}
 
 ### Fill out the information and submit
@@ -111,7 +111,7 @@ Select “set” and fill in your information. As account name just use the acco
 
 ![](/assets/img/wax-bp/bp-json/img02.png){:class="img-responsive"}
 
-If you have done everything correctly bloks.io will confirm your successful transaction. You can have a look at this sample transaction [here](https://wax.bloks.io/transaction/4bfb8f1219abd7f5e231bf54100c35604c0a655d6ff50925a472afdcf6e4bfe9).
+If you have done everything correctly bloks.io will confirm your successful transaction. You can have a look at this sample transaction [here](https://waxblock.io/transaction/4bfb8f1219abd7f5e231bf54100c35604c0a655d6ff50925a472afdcf6e4bfe9).
 
 ![](/assets/img/wax-bp/bp-json/img03.png){:class="img-responsive"}
 

--- a/docs/en/wax-cloud-wallet/boost-wax.md
+++ b/docs/en/wax-cloud-wallet/boost-wax.md
@@ -9,7 +9,7 @@ lang: en
 
 This contract registers other contracts that wish to have WAX apply extended management over CPU and Net for their WAX Cloud Wallet users.
 
-Deployed to: [boost.wax](https://wax.bloks.io/account/boost.wax)
+Deployed to: [boost.wax](https://waxblock.io/account/boost.wax)
 
 
 ## WAX Cloud Wallet Resource Model
@@ -20,9 +20,9 @@ The resource allocation model for WAX Cloud Wallet accounts was designed to be b
 
 WAX Cloud Wallet will allocate up to 5 seconds of CPU and 5M words of NET bandwidth per dApp in a given 24h period; This equals to about 10000 boosted actions per dApp in that time period assuming 0.5 ms average action resource cost. The parameters of the dApp boost resource pool may be adjusted over time as more utilization data becomes available.
    
-Additionally, each dApp can contribute their own WAXP to extend its dApp boost resource pool. dApp smart contract must have a permission called paybw, and it must be linked to the boost.wax#noop action. Furthermore, it must have a 1 of 1 authority using the account@permission boost.wax@paybw. As an example see the [test.wax@paybw permission](https://wax.bloks.io/account/test.wax#keys).
+Additionally, each dApp can contribute their own WAXP to extend its dApp boost resource pool. dApp smart contract must have a permission called paybw, and it must be linked to the boost.wax#noop action. Furthermore, it must have a 1 of 1 authority using the account@permission boost.wax@paybw. As an example see the [test.wax@paybw permission](https://waxblock.io/account/test.wax#keys).
    
-When initial dApp boost resource pool tier is exceeded, the WAX Cloud Wallet will sign for dApps users using this permission if it has sufficient CPU and NET allocated to its contract's account. Each dApp needs to also configure its dApp boost resource pool allocation per user via boost.wax smart contract via [this action](https://wax.bloks.io/account/boost.wax?loadContract=true&tab=Actions&account=boost.wax&scope=boost.wax&limit=100&action=reg).
+When initial dApp boost resource pool tier is exceeded, the WAX Cloud Wallet will sign for dApps users using this permission if it has sufficient CPU and NET allocated to its contract's account. Each dApp needs to also configure its dApp boost resource pool allocation per user via boost.wax smart contract via [this action](https://waxblock.io/account/boost.wax?action=reg#contract-actions).
 
 If dApp pool has available resources then WAX Cloud Wallet will boost users' transactions from that dApp pool and decrement the pool metering accordingly.
    
@@ -44,7 +44,7 @@ WCW creates new accounts with the bare minimum RAM to successfully create each a
 
 ## API
 
-* [reg(name contract, uint64_t cpu_us_per_user, uint64_t net_words_per_user, bool use_allow_list, vector<name> allowed_contracts)](https://wax.bloks.io/account/boost.wax?loadContract=true&tab=Actions&account=boost.wax&scope=boost.wax&limit=100&action=reg)
+* [reg(name contract, uint64_t cpu_us_per_user, uint64_t net_words_per_user, bool use_allow_list, vector<name> allowed_contracts)](https://waxblock.io/account/boost.wax?action=reg#contract-actions)
    Register your contract for bandwidth management.  
    * `contract`: the contract account to register. Must also be the account calling this action.  
    * `cpu_us_per_user`: amount of cpu in microseconds to provide your users over a 24 hour period.  
@@ -52,12 +52,12 @@ WCW creates new accounts with the bare minimum RAM to successfully create each a
    * `use_allow_list`: turn allow list enforcement on or off.
    * `allowed_contracts`: vector of contract name that are permitted to be in transactions accompanying your contract. Must have use_allow_list == true for these to be enforced. The idea is to prevent abuse by dapps that might sneak one of your contract actions into their transactions in order to take advantage of your bandwidth quota. By listing the cotnracts you accept in your contract's transactions, you will only pay with your own cpu+net if all transaction contracts are contained in this list.  
    
-Note: your contract must have a permission called **paybw**, and it must be linked to the **boost.wax**#**noop** action. Furthermore, it must have a 1 of 1 authority usuing the account@permission `boost.wax@paybw`. As an example see the [test.wax@paybw permission](https://wax.bloks.io/account/test.wax#keys). When the free tier is exceeded, the WAX backend will sign for your users using this permission if you have sufficient CPU and Net allocated to your contract's account.
+Note: your contract must have a permission called **paybw**, and it must be linked to the **boost.wax**#**noop** action. Furthermore, it must have a 1 of 1 authority usuing the account@permission `boost.wax@paybw`. As an example see the [test.wax@paybw permission](https://waxblock.io/account/test.wax#keys). When the free tier is exceeded, the WAX backend will sign for your users using this permission if you have sufficient CPU and Net allocated to your contract's account.
    
-* **[dereg(name contract)](https://wax.bloks.io/account/boost.wax?loadContract=true&tab=Tables&account=boost.wax&scope=boost.wax&limit=100&action=dereg)**: 
+* **[dereg(name contract)](https://waxblock.io/account/boost.wax?action=dereg#contract-actions)**: 
    Deregister your contract from bandwidth management.  
    
-* **[noop()](https://wax.bloks.io/account/boost.wax?loadContract=true&tab=Tables&account=boost.wax&scope=boost.wax&limit=100&action=noop)**: 
+* **[noop()](https://waxblock.io/account/boost.wax?action=noop#contract-actions)**: 
    No-op action inserted into WAX Cloud Wallet transactions that satisfy bandwidth management crtieria.  
 
 * **boost(name from, name to, asset cpu, asset net)**: *Deprecated*

--- a/docs/es/dapp-development/dapp_environments.md
+++ b/docs/es/dapp-development/dapp_environments.md
@@ -60,8 +60,8 @@ A continuación, encontrarás versiones de WAX, URLs e información sobre los en
 </tr>
 <tr>
 <td>Explorador de la Blockchain</td>
-<td><a href="https://wax.bloks.io/" target="_blank">https:<span></span>//wax.bloks.io</a></td>
-<td>Explorador Bloks.io.</td>
+<td><a href="https://waxblock.io/" target="_blank">https:<span></span>//waxblock.io</a></td>
+<td>Explorador Waxblock.io.</td>
 </tr>
 
 <tr>

--- a/docs/es/tutorials/howto_atomicassets/collection_struct.md
+++ b/docs/es/tutorials/howto_atomicassets/collection_struct.md
@@ -43,7 +43,7 @@ La descripción y datos de identificación se introducen según la siguiente est
 	{ "name": "creator_info", "type": "string" } 
 ]
 ```
-Si creamos la colección desde un interface como [https://wax.bloks.io](https://wax.bloks.io/account/atomicassets?loadContract=true&tab=Actions&account=atomicassets&scope=atomicassets&limit=100&action=createcol) tendremos que cumplimentar esta entrada de datos:
+Si creamos la colección desde un interface como [https://waxblock.io](https://waxblock.io/account/atomicassets?action=createcol#contract-actions) tendremos que cumplimentar esta entrada de datos:
 
 ![AtomicAssets - createcol action](/assets/img/tutorials/howto_atomicassets/createcol_atomicassets.png)
 


### PR DESCRIPTION
This PR changes all the wax.bloks.io links to waxblock.io links, as the wax.blok.io explorer will be obsolete in the close future. I did not update some wax.blok related articles, as the UI might change for waxblock in the upcoming weeks, so it might make the most sense to just do it once the explorer has reached a more final state