### PR TITLE
Add Wax Awesome

### DIFF
--- a/docs/en/wax-awesome/index.md
+++ b/docs/en/wax-awesome/index.md
@@ -1,0 +1,36 @@
+---
+title: ✨ WAX Awesome
+nav_order: 50
+layout: default
+has_children: true
+has_toc: true
+lang-ref: WAX Awesome
+lang: en
+---
+
+## A curated Lists of awesome projects built on WAX 
+You are new to the WAX Blockchain and you are looking to get started? You want to trade some NFTs or you want built the next big dApp? This list will help you to get started and find the best entrypoints for the WAX blockchain!
+
+**Create a WAX account / Wallets**
+- [WAX Cloud Wallet](https://all-access.wax.io/) 
+- [Anchor](https://greymass.com/en/anchor/)
+
+**Block Explorer**
+- [WaxBlock](https://waxblock.io)
+
+**NFT Marketplaces**
+- [AtomicHub](https://wax.atomichub.io/)
+- [Neftyblocks](https://neftyblocks.com/)
+
+**DEX**
+- [Alcor Exchange](https://alcor.exchange/)
+
+**Free / public API Endpoints (Chain, History and NFT)**
+- [Validationcore.io](https://wax.validationcore.io/reports/nodes/api)
+- [EOS Nation Validator](https://validate.eosnation.io/wax/reports/endpoints.html)
+
+**More Projects**
+- [WaxZilla](https://waxzilla.io/)
+
+**How to contribute to this List:**
+Create a Pull Request on [GitHub](https://github.com/wax-office-of-inspector-general/wax-developer). When creating a Pull Request, please make sure to only submit projects, that help out new users not familiar with the WAX blockchain.


### PR DESCRIPTION
This PR Adds a page called WAX Awesome. The idea is over time we will collect the most important "entrypoints" to the WAX blockchain. This can be wallets, nft marketplaces and so on. Users coming from e.g. ETH should find everything needed to get started, trade nfts and more. I know that some of the information's are already included on some technical pages, but the idea is that this page overtime will have a more high level view on the bigger pictures, while the individual pages cover specific problems such as snapshots etc.