### PR TITLE
proposed COMMENTS on changes to rng_sample.md warning about modulo bias

### DIFF
--- a/docs/build/tutorials/create-wax-rng-smart-contract/rng_sample.md
+++ b/docs/build/tutorials/create-wax-rng-smart-contract/rng_sample.md
@@ -184,10 +184,14 @@ ACTION rngtest::receiverand(uint64_t signing_value, const checksum256& random_va
    require_auth(ORNG_CONTRACT);
 
    //cast the random_value to a smaller number
+   //COMMENT: max_value isn't the max value. Adding +1 to num1 might fix this if you want a number from 1 to 100.
    uint64_t max_value = 100;
    auto byte_array = random_value.extract_as_byte_array();
 
-   uint8_t random_int = 0;
+   //COMMENT: This is a bad practice. SEE: modulo bias
+   //  modulo bias shows 8-bit size for random_int is bad practice due to its size relative to max_value.
+   //  The first (2**8 % max_value) numbers (0-55) will have a +50% increased chance of being chosen in this example.
+   uint8_t random_int = 0; 
    random_int = byte_array[0];
 
    uint8_t num1 = random_int % max_value;
@@ -207,6 +211,8 @@ We extract the first 8 bits of the returned random number and use it to get a nu
 
 **Note:** We still have many bits available in case we need to get more random numbers!
 :::
+
+**COMMENT:** Using only the first 8 bits is bad practice! We need more bits for fairness. SEE: Modulo bias.
 
 We locate the record associated with the request identifier and update its contents to store the returned hash code.
 


### PR DESCRIPTION
Added comments about the following:
max_value isn't actually the max value
the code suffers heavily from modulo bias
the article does not mention modulo biases

I'd suggest changing random_int to a uint64_t and assigning 8 bytes instead of 1; changing num1 to better reflect the notion of a "max_value"; and rewriting the article to warn against small datatypes and modulo biases (possibly with a link on the subject).
=====
The WAX RNG Tutorial rng_sample gives an example of getting a random number (0-99) using a byte. But it doesn't mention modulo bias anywhere. `uint8_t random_int % 100` gives a +50% bias to the first 56 numbers (0-55); a byte isn't large enough to mitigate modulo bias in this case. Modulo bias is an important subject when it comes to RNG, it can be eliminated with rejection sampling, or proper modulo boundaries; or it can be mitigated with large storage space relative to modulus number (e.g. if random_int's data type were uint64_t).

Using a single byte for this would be a bad practice to follow and teach. And I think it might be good for the tutorial to mention modulo biases.

Also it says the max_value is 100 but the max value is probably actually 99. (the largest X % 100 can be is 99).

(Also, the Twitter link in the site's footer leads to the discord, not twitter.)